### PR TITLE
Fix security scan findings: scope IAM permissions, add S3 encryption, and delete IAM cache after assessment

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -139,6 +139,13 @@ phases:
           done
 
           echo "Deploying to management account $AWS_ACCOUNT_ID"
+          # Clean up any leftover SAM managed stack from previous failed runs
+          SAM_STATUS=$(aws cloudformation describe-stacks --stack-name aws-sam-cli-managed-default --query 'Stacks[0].StackStatus' --output text 2>/dev/null)
+          if [[ "$SAM_STATUS" == "ROLLBACK_COMPLETE" || "$SAM_STATUS" == "DELETE_FAILED" ]]; then
+            echo "Cleaning up leftover SAM managed stack (status: $SAM_STATUS)"
+            aws cloudformation delete-stack --stack-name aws-sam-cli-managed-default
+            aws cloudformation wait stack-delete-complete --stack-name aws-sam-cli-managed-default 2>/dev/null || true
+          fi
           if ! sam deploy --template-file .aws-sam/build/template.yaml --stack-name resco-aiml-security-mgmt --capabilities CAPABILITY_IAM --no-confirm-changeset --no-fail-on-empty-changeset --resolve-s3 --region $AWS_DEFAULT_REGION; then
             echo "ERROR: Deploy failed for management account"
             failed_accounts+=($AWS_ACCOUNT_ID)

--- a/deployment/2-aiml-security-codebuild.yaml
+++ b/deployment/2-aiml-security-codebuild.yaml
@@ -199,6 +199,10 @@ Resources:
     Properties:
       VersioningConfiguration:
         Status: Enabled
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: aws:kms
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true

--- a/deployment/2-aiml-security-codebuild.yaml
+++ b/deployment/2-aiml-security-codebuild.yaml
@@ -315,6 +315,12 @@ Resources:
                 Effect: Allow
                 Resource:
                   - !Sub "arn:${AWS::Partition}:cloudformation:*:aws:transform/Serverless-2016-10-31"
+              - Action:
+                  - cloudformation:GetTemplateSummary
+                  - cloudformation:ListStacks
+                  - cloudformation:DescribeStacks
+                Effect: Allow
+                Resource: "*"
         - PolicyName: SAMPermissions
           PolicyDocument:
             Version: "2012-10-17"

--- a/deployment/2-aiml-security-codebuild.yaml
+++ b/deployment/2-aiml-security-codebuild.yaml
@@ -373,6 +373,9 @@ Resources:
                   - states:TagResource
                   - states:UntagResource
                   - states:ListStateMachines
+                  - states:StartExecution
+                  - states:DescribeExecution
+                  - states:ListExecutions
                 Effect: Allow
                 Resource: '*'
               - Sid: S3Permissions

--- a/deployment/2-aiml-security-codebuild.yaml
+++ b/deployment/2-aiml-security-codebuild.yaml
@@ -287,9 +287,30 @@ Resources:
             Version: "2012-10-17"
             Statement:
               - Action:
-                  - cloudformation:*
+                  - cloudformation:CreateStack
+                  - cloudformation:UpdateStack
+                  - cloudformation:DeleteStack
+                  - cloudformation:DescribeStacks
+                  - cloudformation:DescribeStackEvents
+                  - cloudformation:DescribeStackResources
+                  - cloudformation:GetTemplate
+                  - cloudformation:GetTemplateSummary
+                  - cloudformation:ListStackResources
+                  - cloudformation:CreateChangeSet
+                  - cloudformation:DescribeChangeSet
+                  - cloudformation:ExecuteChangeSet
+                  - cloudformation:DeleteChangeSet
+                  - cloudformation:ListStacks
                 Effect: Allow
-                Resource: "*"
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/resco-aiml-*/*"
+                  - !Sub "arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/aws-sam-cli-managed-default/*"
+              - Action:
+                  - cloudformation:GetTemplateSummary
+                  - cloudformation:CreateChangeSet
+                Effect: Allow
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:cloudformation:*:aws:transform/Serverless-2016-10-31"
         - PolicyName: SAMPermissions
           PolicyDocument:
             Version: "2012-10-17"

--- a/deployment/2-aiml-security-codebuild.yaml
+++ b/deployment/2-aiml-security-codebuild.yaml
@@ -377,6 +377,8 @@ Resources:
                 Resource: '*'
               - Sid: S3Permissions
                 Action:
+                  - s3:CreateBucket
+                  - s3:DeleteBucket
                   - s3:PutBucketPolicy
                   - s3:GetBucketPolicy
                   - s3:DeleteBucketPolicy

--- a/deployment/2-aiml-security-codebuild.yaml
+++ b/deployment/2-aiml-security-codebuild.yaml
@@ -318,7 +318,6 @@ Resources:
               - Action:
                   - cloudformation:GetTemplateSummary
                   - cloudformation:ListStacks
-                  - cloudformation:DescribeStacks
                 Effect: Allow
                 Resource: "*"
         - PolicyName: SAMPermissions

--- a/deployment/aiml-security-single-account.yaml
+++ b/deployment/aiml-security-single-account.yaml
@@ -290,6 +290,12 @@ Resources:
                 Effect: Allow
                 Resource:
                   - !Sub "arn:${AWS::Partition}:cloudformation:*:aws:transform/Serverless-2016-10-31"
+              - Action:
+                  - cloudformation:GetTemplateSummary
+                  - cloudformation:ListStacks
+                  - cloudformation:DescribeStacks
+                Effect: Allow
+                Resource: "*"
         - PolicyName: SAMDeploymentPermissions
           PolicyDocument:
             Version: "2012-10-17"

--- a/deployment/aiml-security-single-account.yaml
+++ b/deployment/aiml-security-single-account.yaml
@@ -52,6 +52,10 @@ Resources:
     Properties:
       VersioningConfiguration:
         Status: Enabled
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: aws:kms
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true

--- a/deployment/aiml-security-single-account.yaml
+++ b/deployment/aiml-security-single-account.yaml
@@ -293,7 +293,6 @@ Resources:
               - Action:
                   - cloudformation:GetTemplateSummary
                   - cloudformation:ListStacks
-                  - cloudformation:DescribeStacks
                 Effect: Allow
                 Resource: "*"
         - PolicyName: SAMDeploymentPermissions

--- a/deployment/aiml-security-single-account.yaml
+++ b/deployment/aiml-security-single-account.yaml
@@ -261,9 +261,31 @@ Resources:
             Version: "2012-10-17"
             Statement:
               - Action:
-                  - cloudformation:*
+                  - cloudformation:CreateStack
+                  - cloudformation:UpdateStack
+                  - cloudformation:DeleteStack
+                  - cloudformation:DescribeStacks
+                  - cloudformation:DescribeStackEvents
+                  - cloudformation:DescribeStackResources
+                  - cloudformation:GetTemplate
+                  - cloudformation:GetTemplateSummary
+                  - cloudformation:ListStackResources
+                  - cloudformation:CreateChangeSet
+                  - cloudformation:DescribeChangeSet
+                  - cloudformation:ExecuteChangeSet
+                  - cloudformation:DeleteChangeSet
+                  - cloudformation:ListStacks
                 Effect: Allow
-                Resource: "*"
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/resco-aiml-*/*"
+                  - !Sub "arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/aiml-sec-*/*"
+                  - !Sub "arn:${AWS::Partition}:cloudformation:*:${AWS::AccountId}:stack/aws-sam-cli-managed-default/*"
+              - Action:
+                  - cloudformation:GetTemplateSummary
+                  - cloudformation:CreateChangeSet
+                Effect: Allow
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:cloudformation:*:aws:transform/Serverless-2016-10-31"
         - PolicyName: SAMDeploymentPermissions
           PolicyDocument:
             Version: "2012-10-17"

--- a/resco-aiml-assessment/functions/security/generate_consolidated_report/app.py
+++ b/resco-aiml-assessment/functions/security/generate_consolidated_report/app.py
@@ -604,6 +604,16 @@ def lambda_handler(event, context):
         # in the CodeBuild post-build phase, not here. This Lambda only generates
         # the per-account security_assessment_*.html report.
 
+        # Delete the IAM permissions cache file — it contains full policy documents
+        # and should not persist in S3 after the assessment completes
+        try:
+            cache_key = f'permissions_cache_{execution_id}.json'
+            s3_client = boto3.client('s3', config=boto3_config)
+            s3_client.delete_object(Bucket=s3_bucket, Key=cache_key)
+            logger.info(f"Deleted permissions cache: {cache_key}")
+        except Exception as cache_err:
+            logger.warning(f"Failed to delete permissions cache: {cache_err}")
+
         return {
             'statusCode': 200,
             'executionId': execution_id,

--- a/resco-aiml-assessment/template-multi-account.yaml
+++ b/resco-aiml-assessment/template-multi-account.yaml
@@ -388,6 +388,10 @@ Resources:
     Properties:
       VersioningConfiguration:
         Status: Enabled
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: aws:kms
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true

--- a/resco-aiml-assessment/template.yaml
+++ b/resco-aiml-assessment/template.yaml
@@ -392,6 +392,10 @@ Resources:
     Properties:
       VersioningConfiguration:
         Status: Enabled
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: aws:kms
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true


### PR DESCRIPTION
### Description:

Addresses critical and high severity findings from the security scan (cfn_nag, checkov, semgrep).

### Changes:

IAM Permission Scoping (Critical)
- Replace cloudformation:* with explicit actions scoped to resco-aiml-*, aiml-sec-*, and aws-sam-cli-managed-default stack patterns in both 2-aiml-security-codebuild.yaml and aiml-security-single-account.yaml
- Add separate statement for GetTemplateSummary and ListStacks which require Resource: '*' (don't support resource-level permissions)
- Add states:StartExecution, states:DescribeExecution, states:ListExecutions to CodeBuild role
- Add s3:CreateBucket and s3:DeleteBucket to CodeBuild role S3 permissions
- Replace bedrock-agentcore:* with 5 explicit actions in template-multi-account.yaml

### S3 Encryption (High)
- Add BucketEncryption with SSEAlgorithm: aws:kms (AWS-managed key) to all 4 S3 bucket definitions across template.yaml, template-multi-account.yaml, 2-aiml-security-codebuild.yaml, and aiml-security-single-account.yaml

### IAM Permissions Cache Deletion (High)
- Delete permissions_cache_{execution_id}.json from S3 at the end of generate_consolidated_report Lambda after the HTML report is generated
- This file contains full IAM policy documents for all roles/users and should not persist between assessment runs

### Buildspec Improvements
- Add cleanup of leftover aws-sam-cli-managed-default stack before management account deploy to handle ROLLBACK_COMPLETE state from previous failed runs

### Semgrep Suppressions
- Add # nosemgrep: arbitrary-sleep to intentional time.sleep() calls in IAM service-last-accessed polling loops (bedrock, sagemaker, agentcore assessments)

### Testing
- Single-account: tested on 914787431788 (us-east-1) — all reports generated, no permissions cache in bucket, KMS encryption verified
- Multi-account: tested on 776723054987 org (us-east-1) — 5 accounts assessed successfully, management account deploys and executes, consolidated report generated, no JSON files in central bucket