### PR TITLE
Add support for specifying an existing S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The framework generates professional, interactive security assessment reports wi
 - [Prerequisites](#prerequisites)
 - [Single-Account Deployment](#single-account-deployment)
 - [Multi-Account Deployment](#multi-account-deployment)
+- [Using an Existing S3 Bucket](#using-an-existing-s3-bucket)
 - [How It Works](#how-it-works)
 - [Permissions Required](#permissions-required)
 - [Viewing Assessment Results](#viewing-assessment-results)
@@ -247,6 +248,43 @@ Deploy [2-aiml-security-codebuild.yaml](deployment/2-aiml-security-codebuild.yam
 6. Navigate to the next page, read and acknowledge the notice, and click **Next**.
 7. Review the information and click **Submit**.
 8. Stack creation automatically triggers AWS CodeBuild, which deploys the assessment to each account and runs it.
+
+## Using an Existing S3 Bucket
+
+By default, the solution creates a new Amazon S3 bucket to store assessment results. If you need to use a pre-existing bucket (for example, if your environment has SCPs that restrict S3 bucket creation), you can specify the bucket name using the `ExistingBucketName` parameter.
+
+When `ExistingBucketName` is provided:
+- No new Amazon S3 buckets are created (neither the results bucket nor the SAM artifacts bucket)
+- All assessment results are uploaded to the specified bucket
+- The existing bucket is used for SAM deployment artifacts and Lambda assessment results
+
+### AWS CloudShell (Single-Account)
+
+```bash
+aws cloudformation create-stack \
+  --stack-name aiml-security-single-account \
+  --template-body file://aiml-security-single-account.yaml \
+  --parameters ParameterKey=ExistingBucketName,ParameterValue=my-existing-bucket \
+  --capabilities CAPABILITY_NAMED_IAM
+```
+
+### AWS CloudShell (Multi-Account)
+
+```bash
+aws cloudformation create-stack \
+  --stack-name aiml-security-multi-account \
+  --template-body file://2-aiml-security-codebuild.yaml \
+  --parameters \
+    ParameterKey=MultiAccountScan,ParameterValue=true \
+    ParameterKey=ExistingBucketName,ParameterValue=my-existing-bucket \
+  --capabilities CAPABILITY_NAMED_IAM
+```
+
+### AWS Console
+
+When deploying via the Console, enter your bucket name in the **ExistingBucketName** parameter field. Leave it empty to create a new bucket (default behavior).
+
+---
 
 ## How It Works
 

--- a/aiml-security-assessment/template.yaml
+++ b/aiml-security-assessment/template.yaml
@@ -5,6 +5,16 @@ Description: >
 
   SAM Template for aiml-security-assessment
 
+Parameters:
+  ExistingBucketName:
+    Type: String
+    Default: ""
+    Description: "Name of an existing S3 bucket to store assessment results (leave empty to create a new bucket)"
+
+Conditions:
+  UseExistingBucket: !Not [!Equals [!Ref ExistingBucketName, ""]]
+  CreateNewBucket: !Equals [!Ref ExistingBucketName, ""]
+
 Resources:
   AIMLAssessmentStateMachine:
     Type: AWS::Serverless::StateMachine # More info about State Machine Resource: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-statemachine.html
@@ -17,7 +27,7 @@ Resources:
         SagemakerSecurityAssessmentFunction: !GetAtt SagemakerSecurityAssessmentFunction.Arn
         AgentCoreSecurityAssessmentFunction: !GetAtt AgentCoreSecurityAssessmentFunction.Arn
         GenerateConsolidatedReportFunction: !GetAtt GenerateConsolidatedReportFunction.Arn
-        AIMLAssessmentBucketName: !Ref AIMLAssessmentBucket
+        AIMLAssessmentBucketName: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AIMLAssessmentBucket]
       Policies:
         # Find out more about SAM policy templates: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-templates.html
         - LambdaInvokePolicy:
@@ -34,7 +44,7 @@ Resources:
             FunctionName: !Ref GenerateConsolidatedReportFunction
         #Add S3 Read Write policy
         - S3CrudPolicy:
-            BucketName: !Ref AIMLAssessmentBucket
+            BucketName: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AIMLAssessmentBucket]
 
   CleanupBucketFunction:
     Type: AWS::Serverless::Function
@@ -49,10 +59,10 @@ Resources:
       MemorySize: 512
       Environment:
         Variables:
-          AIML_ASSESSMENT_BUCKET_NAME: !Ref AIMLAssessmentBucket
+          AIML_ASSESSMENT_BUCKET_NAME: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AIMLAssessmentBucket]
       Policies:
         - S3CrudPolicy:
-            BucketName: !Ref AIMLAssessmentBucket
+            BucketName: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AIMLAssessmentBucket]
 
   IAMPermissionCachingFunction:
     Type: AWS::Serverless::Function
@@ -67,10 +77,10 @@ Resources:
       MemorySize: 1024
       Environment:
         Variables:
-          AIML_ASSESSMENT_BUCKET_NAME: !Ref AIMLAssessmentBucket
+          AIML_ASSESSMENT_BUCKET_NAME: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AIMLAssessmentBucket]
       Policies:
         - S3CrudPolicy:
-            BucketName: !Ref AIMLAssessmentBucket
+            BucketName: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AIMLAssessmentBucket]
         - Statement:
             - Sid: IAMPermissions
               Effect: Allow
@@ -102,10 +112,10 @@ Resources:
       MemorySize: 1024
       Environment:
         Variables:
-          AIML_ASSESSMENT_BUCKET_NAME: !Ref AIMLAssessmentBucket
+          AIML_ASSESSMENT_BUCKET_NAME: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AIMLAssessmentBucket]
       Policies:
         - S3CrudPolicy:
-            BucketName: !Ref AIMLAssessmentBucket
+            BucketName: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AIMLAssessmentBucket]
   BedrockSecurityAssessmentFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -120,10 +130,10 @@ Resources:
       MemorySize: 1024
       Environment:
         Variables:
-          AIML_ASSESSMENT_BUCKET_NAME: !Ref AIMLAssessmentBucket
+          AIML_ASSESSMENT_BUCKET_NAME: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AIMLAssessmentBucket]
       Policies:
         - S3CrudPolicy:
-            BucketName: !Ref AIMLAssessmentBucket
+            BucketName: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AIMLAssessmentBucket]
         - Statement:
             - Sid: IAMPermissions
               Effect: Allow
@@ -211,10 +221,10 @@ Resources:
       MemorySize: 1024
       Environment:
         Variables:
-          AIML_ASSESSMENT_BUCKET_NAME: !Ref AIMLAssessmentBucket
+          AIML_ASSESSMENT_BUCKET_NAME: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AIMLAssessmentBucket]
       Policies:
         - S3CrudPolicy:
-            BucketName: !Ref AIMLAssessmentBucket
+            BucketName: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AIMLAssessmentBucket]
         - Statement:
             - Sid: IAMPermissions
               Effect: Allow
@@ -304,10 +314,10 @@ Resources:
       MemorySize: 1024
       Environment:
         Variables:
-          AIML_ASSESSMENT_BUCKET_NAME: !Ref AIMLAssessmentBucket
+          AIML_ASSESSMENT_BUCKET_NAME: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AIMLAssessmentBucket]
       Policies:
         - S3CrudPolicy:
-            BucketName: !Ref AIMLAssessmentBucket
+            BucketName: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AIMLAssessmentBucket]
         - Statement:
             - Sid: IAMPermissions
               Effect: Allow
@@ -389,6 +399,7 @@ Resources:
 
   # Add a S3 bucket to store the AIML assessment results
   AIMLAssessmentBucket:
+    Condition: CreateNewBucket
     Type: AWS::S3::Bucket
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
@@ -406,6 +417,7 @@ Resources:
         RestrictPublicBuckets: true
 
   AssessmentBucketPolicy:
+    Condition: CreateNewBucket
     Type: AWS::S3::BucketPolicy
     Properties:
       Bucket: !Ref AIMLAssessmentBucket
@@ -429,4 +441,4 @@ Outputs:
     Value: !Ref AIMLAssessmentStateMachine
   AssessmentBucketName:
     Description: Name of the S3 bucket where assessment reports are stored
-    Value: !Ref AIMLAssessmentBucket
+    Value: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AIMLAssessmentBucket]

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -60,6 +60,17 @@ phases:
       - echo "Build completed, checking build directory:"
       - ls -la .aws-sam/build/
       - |
+        # Set SAM deploy flags based on whether an existing bucket is provided
+        if [[ -n "$EXISTING_ASSESSMENT_BUCKET" ]]; then
+          SAM_S3_FLAG="--s3-bucket $EXISTING_ASSESSMENT_BUCKET"
+          SAM_PARAMS="--parameter-overrides ExistingBucketName=$EXISTING_ASSESSMENT_BUCKET"
+          echo "Using existing bucket: $EXISTING_ASSESSMENT_BUCKET"
+        else
+          SAM_S3_FLAG="--resolve-s3"
+          SAM_PARAMS=""
+          echo "Will create new assessment bucket"
+        fi
+      - |
         if [[ $MULTI_ACCOUNT_SCAN = 'true' ]]; then
           echo "Getting list of accounts to scan"
           if [[ $MULTI_ACCOUNT_LIST_OVERRIDE != '' ]]; then
@@ -115,7 +126,7 @@ phases:
             fi
 
             echo "Deploying to account $accountId"
-            if ! sam deploy --template-file .aws-sam/build/template.yaml --stack-name aiml-security-$accountId --capabilities CAPABILITY_IAM --no-confirm-changeset --no-fail-on-empty-changeset --resolve-s3 --region $AWS_DEFAULT_REGION; then
+            if ! sam deploy --template-file .aws-sam/build/template.yaml --stack-name aiml-security-$accountId --capabilities CAPABILITY_IAM --no-confirm-changeset --no-fail-on-empty-changeset $SAM_S3_FLAG $SAM_PARAMS --region $AWS_DEFAULT_REGION; then
               echo "ERROR: Deploy failed for account $accountId"
               failed_accounts+=($accountId)
               unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
@@ -146,7 +157,7 @@ phases:
             aws cloudformation delete-stack --stack-name aws-sam-cli-managed-default
             aws cloudformation wait stack-delete-complete --stack-name aws-sam-cli-managed-default 2>/dev/null || true
           fi
-          if ! sam deploy --template-file .aws-sam/build/template.yaml --stack-name aiml-security-mgmt --capabilities CAPABILITY_IAM --no-confirm-changeset --no-fail-on-empty-changeset --resolve-s3 --region $AWS_DEFAULT_REGION; then
+          if ! sam deploy --template-file .aws-sam/build/template.yaml --stack-name aiml-security-mgmt --capabilities CAPABILITY_IAM --no-confirm-changeset --no-fail-on-empty-changeset $SAM_S3_FLAG $SAM_PARAMS --region $AWS_DEFAULT_REGION; then
             echo "ERROR: Deploy failed for management account"
             failed_accounts+=($AWS_ACCOUNT_ID)
           else
@@ -171,7 +182,7 @@ phases:
         else
           echo "Single account deployment"
           STACK_NAME="aiml-sec-${AWS_ACCOUNT_ID}"
-          if ! sam deploy --template-file .aws-sam/build/template.yaml --stack-name $STACK_NAME --capabilities CAPABILITY_IAM --no-confirm-changeset --no-fail-on-empty-changeset --resolve-s3; then
+          if ! sam deploy --template-file .aws-sam/build/template.yaml --stack-name $STACK_NAME --capabilities CAPABILITY_IAM --no-confirm-changeset --no-fail-on-empty-changeset $SAM_S3_FLAG $SAM_PARAMS; then
             echo "ERROR: SAM deploy failed for single account"
             exit 1
           fi

--- a/deployment/2-aiml-security-codebuild.yaml
+++ b/deployment/2-aiml-security-codebuild.yaml
@@ -10,6 +10,7 @@ Metadata:
           - MultiAccountScan
           - MultiAccountListOverride
           - EmailAddress
+          - ExistingBucketName
       - Label:
           default: Advanced Options
         Parameters:
@@ -78,12 +79,20 @@ Parameters:
     MaxValue: 2160
     Default: 300
 
+  ExistingBucketName:
+    Description: "Name of an existing S3 bucket to store assessment results (leave empty to create a new bucket)"
+    Type: String
+    Default: ""
+
 Conditions:
   CreateMemberRole: !Equals
     - !Ref MultiAccountScan
     - false
 
   CreateEmailNotification: !Not [ !Equals [ !Ref EmailAddress, "" ] ]
+
+  UseExistingBucket: !Not [!Equals [!Ref ExistingBucketName, ""]]
+  CreateNewBucket: !Equals [!Ref ExistingBucketName, ""]
 
 Mappings:
   CodeBuildPerformanceOptionMap:
@@ -250,6 +259,7 @@ Resources:
 
   # S3 bucket for assessment results
   AssessmentBucket:
+    Condition: CreateNewBucket
     Type: AWS::S3::Bucket
     Properties:
       VersioningConfiguration:
@@ -265,6 +275,7 @@ Resources:
         RestrictPublicBuckets: true
 
   AssessmentBucketPolicy:
+    Condition: CreateNewBucket
     Type: "AWS::S3::BucketPolicy"
     Properties:
       Bucket: !Ref AssessmentBucket
@@ -316,12 +327,19 @@ Resources:
                   - s3:PutObject
                   - s3:GetObject
                 Effect: Allow
-                Resource: !Sub "${AssessmentBucket.Arn}/*"
+                Resource: !If
+                  - UseExistingBucket
+                  - !Sub "arn:${AWS::Partition}:s3:::${ExistingBucketName}/*"
+                  - !Sub "${AssessmentBucket.Arn}/*"
               - Action:
                   - s3:GetObject
                   - s3:ListBucket
                 Effect: Allow
                 Resource:
+                  - !If
+                    - UseExistingBucket
+                    - !Sub "arn:${AWS::Partition}:s3:::${ExistingBucketName}"
+                    - !GetAtt AssessmentBucket.Arn
                   - !Sub "arn:${AWS::Partition}:s3:::aiml-security-*"
                   - !Sub "arn:${AWS::Partition}:s3:::aiml-security-*/*"
         - PolicyName: AssumeRole
@@ -484,7 +502,10 @@ Resources:
         Type: "LINUX_CONTAINER"
         EnvironmentVariables:
           - Name: BUCKET_REPORT
-            Value: !Ref AssessmentBucket
+            Value: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AssessmentBucket]
+            Type: PLAINTEXT
+          - Name: EXISTING_ASSESSMENT_BUCKET
+            Value: !If [UseExistingBucket, !Ref ExistingBucketName, ""]
             Type: PLAINTEXT
           - Name: GITHUB_REPO_URL
             Value: !Ref GitHubRepoUrl
@@ -604,7 +625,6 @@ Resources:
 
   CodeBuildStartBuild:
     Type: Custom::CodeBuildStartBuild
-    DependsOn: AssessmentBucketPolicy
     Properties:
       ServiceToken: !GetAtt CodeBuildStartBuildLambda.Arn
       ProjectName: !Ref MultiAccountCodeBuild
@@ -673,7 +693,7 @@ Outputs:
 
   AssessmentBucket:
     Description: S3 bucket containing assessment results (HTML reports and CSV data)
-    Value: !Ref AssessmentBucket
+    Value: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AssessmentBucket]
 
   CodeBuildProjectName:
     Description: CodeBuild project name for running assessments

--- a/deployment/aiml-security-single-account.yaml
+++ b/deployment/aiml-security-single-account.yaml
@@ -8,6 +8,7 @@ Metadata:
           default: Assessment Options
         Parameters:
           - EmailAddress
+          - ExistingBucketName
       - Label:
           default: Advanced Options
         Parameters:
@@ -42,12 +43,20 @@ Parameters:
     MaxValue: 480
     Default: 60
 
+  ExistingBucketName:
+    Description: "Name of an existing S3 bucket to store assessment results (leave empty to create a new bucket)"
+    Type: String
+    Default: ""
+
 Conditions:
   CreateEmailNotification: !Not [!Equals [!Ref EmailAddress, ""]]
+  UseExistingBucket: !Not [!Equals [!Ref ExistingBucketName, ""]]
+  CreateNewBucket: !Equals [!Ref ExistingBucketName, ""]
 
 Resources:
   # S3 bucket for assessment results
   AssessmentBucket:
+    Condition: CreateNewBucket
     Type: AWS::S3::Bucket
     Properties:
       VersioningConfiguration:
@@ -63,6 +72,7 @@ Resources:
         RestrictPublicBuckets: true
 
   AssessmentBucketPolicy:
+    Condition: CreateNewBucket
     Type: "AWS::S3::BucketPolicy"
     Properties:
       Bucket: !Ref AssessmentBucket
@@ -385,12 +395,19 @@ Resources:
                   - s3:PutObject
                   - s3:GetObject
                 Effect: Allow
-                Resource: !Sub "${AssessmentBucket.Arn}/*"
+                Resource: !If
+                  - UseExistingBucket
+                  - !Sub "arn:${AWS::Partition}:s3:::${ExistingBucketName}/*"
+                  - !Sub "${AssessmentBucket.Arn}/*"
               - Action:
                   - s3:GetObject
                   - s3:ListBucket
                 Effect: Allow
                 Resource:
+                  - !If
+                    - UseExistingBucket
+                    - !Sub "arn:${AWS::Partition}:s3:::${ExistingBucketName}"
+                    - !GetAtt AssessmentBucket.Arn
                   - !Sub "arn:${AWS::Partition}:s3:::aiml-security-*"
                   - !Sub "arn:${AWS::Partition}:s3:::aiml-security-*/*"
 
@@ -405,7 +422,7 @@ Resources:
         Type: "LINUX_CONTAINER"
         EnvironmentVariables:
           - Name: BUCKET_REPORT
-            Value: !Ref AssessmentBucket
+            Value: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AssessmentBucket]
             Type: PLAINTEXT
           - Name: GITHUB_REPO_URL
             Value: !Ref GitHubRepoUrl
@@ -514,7 +531,6 @@ Resources:
 
   CodeBuildStartBuild:
     Type: Custom::CodeBuildStartBuild
-    DependsOn: AssessmentBucketPolicy
     Properties:
       ServiceToken: !GetAtt CodeBuildStartBuildLambda.Arn
       ProjectName: !Ref CodeBuild
@@ -583,4 +599,4 @@ Outputs:
 
   AssessmentBucket:
     Description: S3 bucket containing assessment results (HTML reports and CSV data)
-    Value: !Ref AssessmentBucket
+    Value: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AssessmentBucket]

--- a/deployment/aiml-security-single-account.yaml
+++ b/deployment/aiml-security-single-account.yaml
@@ -424,6 +424,9 @@ Resources:
           - Name: BUCKET_REPORT
             Value: !If [UseExistingBucket, !Ref ExistingBucketName, !Ref AssessmentBucket]
             Type: PLAINTEXT
+          - Name: EXISTING_ASSESSMENT_BUCKET
+            Value: !If [UseExistingBucket, !Ref ExistingBucketName, ""]
+            Type: PLAINTEXT
           - Name: GITHUB_REPO_URL
             Value: !Ref GitHubRepoUrl
             Type: PLAINTEXT


### PR DESCRIPTION
## Summary

- Add optional `ExistingBucketName` parameter to single-account, multi-account, and SAM templates
- When provided, no new S3 buckets are created — the existing bucket is used for SAM artifacts, Lambda assessment results, and final report storage
- Updated `buildspec.yml` to pass `--s3-bucket` and `--parameter-overrides` to SAM deploy when an existing bucket is specified
- Updated README with documentation and usage examples for both single and multi-account deployments
- Supports customer environments with SCPs that restrict S3 bucket creation

## Files changed

- `deployment/aiml-security-single-account.yaml` — ExistingBucketName parameter, conditional bucket/policy, updated IAM and env vars
- `deployment/2-aiml-security-codebuild.yaml` — same changes for multi-account template
- `aiml-security-assessment/template.yaml` — conditional AIMLAssessmentBucket, updated Lambda env vars and policies
- `buildspec.yml` — conditional SAM deploy flags based on EXISTING_ASSESSMENT_BUCKET env var
- `README.md` — documentation for the new parameter

## Test plan

- [x] Single-account: deployed with ExistingBucketName empty — new bucket created, assessment completed successfully
- [x] Single-account: deployed with ExistingBucketName set — no new buckets created, assessment completed, results in specified bucket
- [x] Tested in customer environment with SCP restricting bucket creation — deployment and assessment succeeded