### PR TITLE
Upgrade CodeBuild image to Amazon Linux 2023 standard 6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .kiro/
 .vscode/
 .claude/
+.codex/
 .mcp.json
 
 # AWS SAM build artifacts
@@ -12,6 +13,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 *.pyc
+.pytest_cache/
 
 # OS files
 .DS_Store
@@ -40,3 +42,4 @@ samples/
 **/test_reports/
 
 .ruff_cache/
+.ash/

--- a/deployment/2-aiml-security-codebuild.yaml
+++ b/deployment/2-aiml-security-codebuild.yaml
@@ -480,7 +480,7 @@ Resources:
             !Ref ConcurrentAccountScans,
             "CodeBuildComputeType",
           ]
-        Image: "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
+        Image: "aws/codebuild/amazonlinux-x86_64-standard:6.0"
         Type: "LINUX_CONTAINER"
         EnvironmentVariables:
           - Name: BUCKET_REPORT

--- a/deployment/aiml-security-single-account.yaml
+++ b/deployment/aiml-security-single-account.yaml
@@ -401,7 +401,7 @@ Resources:
       Name: AIMLSecurityCodeBuild
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
+        Image: "aws/codebuild/amazonlinux-x86_64-standard:6.0"
         Type: "LINUX_CONTAINER"
         EnvironmentVariables:
           - Name: BUCKET_REPORT


### PR DESCRIPTION
## Summary

Upgrades the CodeBuild environment image used by both the single-account and multi-account assessment stacks from the Amazon Linux 2 standard 4.0 image to the Amazon Linux 2023 standard 6.0 image.

The previous `aws/codebuild/amazonlinux2-x86_64-standard:4.0` image is an older generation (AL2) on the path to deprecation. Moving to `aws/codebuild/amazonlinux-x86_64-standard:6.0` (AL2023) keeps the build environment on a current, supported image with up-to-date default runtimes.

## Changes

- **`deployment/aiml-security-single-account.yaml`** — CodeBuild `Image` updated to `aws/codebuild/amazonlinux-x86_64-standard:6.0`
- **`deployment/2-aiml-security-codebuild.yaml`** — same image update for the multi-account stack
- **`.gitignore`** — ignore `.codex/`, `.pytest_cache/`, and `.ash/`

## Compatibility notes

- `buildspec.yml` pins `python: 3.12` under `runtime-versions`, which the AL2023 standard 6.0 image supports — no buildspec change required.
- The AL2023 image ships newer default toolchain versions (Python, Node, etc.) than AL2 4.0.

## Testing

- An assessment was run end-to-end on the new AL2023 6.0 image; the build provisioned correctly and the assessment Step Function completed successfully.