### PR TITLE
Expand and harden Amazon Bedrock security checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Open-source automated security scanner for generative AI and machine learning workloads on AWS.** Core checks for Amazon Bedrock, Amazon SageMaker AI, and Amazon Bedrock AgentCore are built on the [AWS Well-Architected Framework — Generative AI Lens](https://docs.aws.amazon.com/wellarchitected/latest/generative-ai-lens/generative-ai-lens.html). An optional Financial Services GenAI risk module adds 64 checks aligned to the [AWS User Guide to Governance, Risk, and Compliance for Responsible AI Adoption within Financial Services Industries](https://d1.awsstatic.com/onedam/marketing-channels/website/aws/en_US/whitepapers/compliance/AWS-User-Guide-Governance-Risk-Compliance-for-Responsible-AI-Adoption-Financial-Services.pdf). See the [AWS Security Blog announcement](https://aws.amazon.com/blogs/security/introducing-the-updated-aws-user-guide-to-governance-risk-and-compliance-for-responsible-ai-adoption/) for context on the updated guide.
 
-Run **[116 security checks](docs/SECURITY_CHECKS.md)** across your AWS accounts and regions in one deployment. Surfaces IAM misconfigurations, encryption gaps, network isolation issues, missing guardrails, and governance gaps — with interactive HTML reports, severity ratings, and AWS documentation links for remediation. Single-account or full AWS Organizations multi-account scans; all data stays in your account.
+Run **[134 security checks](docs/SECURITY_CHECKS.md)** across your AWS accounts and regions in one deployment. Surfaces IAM misconfigurations, encryption gaps, network isolation issues, missing guardrails, and governance gaps — with interactive HTML reports, severity ratings, and AWS documentation links for remediation. Single-account or full AWS Organizations multi-account scans; all data stays in your account.
 
 ---
 
@@ -39,7 +39,7 @@ The framework generates professional, interactive security assessment reports wi
 
 - **Executive Summary** with severity counts and service breakdown
 - **Priority Recommendations** highlighting critical issues requiring immediate attention
-- **[116 Security Checks](docs/SECURITY_CHECKS.md)** across Amazon Bedrock, Amazon SageMaker AI, Amazon Bedrock AgentCore, and Financial Services GenAI Risk
+- **[134 Security Checks](docs/SECURITY_CHECKS.md)** across Amazon Bedrock, Amazon SageMaker AI, Amazon Bedrock AgentCore, and Financial Services GenAI Risk
 - **Multi-Region Support** for core Bedrock, SageMaker, and AgentCore checks, with per-region risk breakdown
 - **Interactive Filtering** by account, region, service, severity, and status
 - **Light/Dark Mode Toggle** with persistent user preference
@@ -83,14 +83,14 @@ Designed for workloads using [Amazon Bedrock](https://aws.amazon.com/bedrock/), 
 | Challenge | How This Framework Helps |
 |-----------|-------------------------|
 | **Manual security audits are time-consuming** | Fully automated scanning with one-click CloudFormation deployment |
-| **Inconsistent security checks across teams** | Standardized 116-check assessment based on AWS Well-Architected Generative AI Lens best practices and AWS Responsible AI governance, risk, and compliance guidance for financial services |
+| **Inconsistent security checks across teams** | Standardized 134-check assessment based on AWS Well-Architected Generative AI Lens best practices and AWS Responsible AI governance, risk, and compliance guidance for financial services |
 | **Difficulty tracking AI/ML security posture** | Interactive HTML dashboards with severity breakdown and per-account visibility |
 | **Multi-account complexity** | Consolidated reporting across AWS Organizations with cross-account role assumption |
 | **Compliance and audit support** | Exportable reports to supplement your compliance program, with remediation guidance linked to AWS documentation |
 | **Generative AI security gaps** | Purpose-built checks for LLM guardrails, model access controls, and prompt injection prevention |
 
 **Services Covered:**
-- **[Amazon Bedrock](docs/SECURITY_CHECKS.md#amazon-bedrock-security-checks-14)** (14 checks) - Guardrails, encryption, Amazon VPC endpoints, AWS IAM permissions, model invocation logging
+- **[Amazon Bedrock](docs/SECURITY_CHECKS.md#amazon-bedrock-security-checks-32)** (32 checks) - Guardrails, cross-account policies, guardrail tiers, content filters, sensitive-information/PII filters, contextual grounding, automated reasoning, encryption (custom, imported, knowledge base, and batch inference output), Amazon VPC endpoints, AWS IAM permissions, agent guardrail association and least privilege, model invocation logging, CloudWatch alarms, model evaluation, prompt flow validation, RAG evaluation, service quotas
 - **[Amazon SageMaker AI](docs/SECURITY_CHECKS.md#amazon-sagemaker-ai-security-checks-25)** (25 checks) - AWS Security Hub controls (SageMaker.1-5), encryption, network isolation, AWS IAM, MLOps
 - **[Amazon Bedrock AgentCore](docs/SECURITY_CHECKS.md#amazon-bedrock-agentcore-security-checks-13)** (13 checks) - Amazon VPC configuration, encryption, observability, resource policies
 - **[Financial Services GenAI Risk](docs/SECURITY_CHECKS.md#financial-services-genai-risk-checks-64-additional-5-upstream-extensions)** (64 checks) - Unbounded consumption, excessive agency, supply chain, training data poisoning, hallucination, prompt injection, PII disclosure, and 8 more FinServ-specific risk categories derived from the [AWS User Guide to Governance, Risk, and Compliance for Responsible AI Adoption within Financial Services Industries](https://d1.awsstatic.com/onedam/marketing-channels/website/aws/en_US/whitepapers/compliance/AWS-User-Guide-Governance-Risk-Compliance-for-Responsible-AI-Adoption-Financial-Services.pdf). See the [AWS Security Blog announcement](https://aws.amazon.com/blogs/security/introducing-the-updated-aws-user-guide-to-governance-risk-and-compliance-for-responsible-ai-adoption/) for context on the updated guide.
@@ -115,7 +115,7 @@ This tool operates within the [AWS Shared Responsibility Model](https://aws.amaz
 
 **No guarantee of security or compliance.** This framework identifies common misconfigurations based on AWS best practices and the AWS Well-Architected Framework. It does not cover all possible security risks, does not replace formal compliance audits (SOC 2, HIPAA, and similar), and does not guarantee that your workloads are secure. Use the results as one input into your broader security program.
 
-**116 checks across four domains.** The assessment covers Amazon Bedrock, Amazon SageMaker AI, Amazon Bedrock AgentCore, and optional Financial Services GenAI risk checks. Other AI/ML services (Amazon Comprehend, Amazon Rekognition, Amazon Textract, and others) are not currently assessed.
+**134 checks across four domains.** The assessment covers Amazon Bedrock, Amazon SageMaker AI, Amazon Bedrock AgentCore, and optional Financial Services GenAI risk checks. Other AI/ML services (Amazon Comprehend, Amazon Rekognition, Amazon Textract, and others) are not currently assessed.
 
 ---
 
@@ -386,7 +386,7 @@ If you need to reduce scope, review the role policies in:
 
 | Document | Description |
 |----------|-------------|
-| [Security Checks Reference](docs/SECURITY_CHECKS.md) | Complete reference for all 116 security checks with severity levels |
+| [Security Checks Reference](docs/SECURITY_CHECKS.md) | Complete reference for all 134 security checks with severity levels |
 | [FinServ GenAI Risk Checks](docs/SECURITY_CHECKS_FINSERV.md) | Complete FS-01..69 reference: shared introduction, severity rubric, upstream-overlap table, compliance framework mapping, and all check definitions (Part 1 infrastructure controls, Part 2 guardrails & content safety, Part 3 app-layer controls & gaps) |
 | [FinServ Severity Methodology](docs/SECURITY_CHECKS_FINSERV_SEVERITY_METHODOLOGY.md) | Likelihood × Impact → ASFF severity model, disposition rules, and research basis for FS check severities |
 | [FinServ Severity Register](docs/SECURITY_CHECKS_FINSERV_SEVERITY_REGISTER.md) | Authoritative per-finding severity assignments (the single source of truth enforced by the drift-guard test) |

--- a/aiml-security-assessment/functions/security/agentcore_assessments/requirements.txt
+++ b/aiml-security-assessment/functions/security/agentcore_assessments/requirements.txt
@@ -1,3 +1,4 @@
-boto3>=1.39.8
+boto3==1.43.32
+botocore==1.43.32
 pydantic>=2.0
 typing-extensions

--- a/aiml-security-assessment/functions/security/bedrock_assessments/app.py
+++ b/aiml-security-assessment/functions/security/bedrock_assessments/app.py
@@ -69,6 +69,20 @@ def is_account_not_authorized(error: Exception) -> bool:
     )
 
 
+def is_region_unsupported(error: Exception) -> bool:
+    """
+    Detect a "this API/feature is not available in this region" error.
+
+    Several Bedrock features (Knowledge Bases, Agents, Flows, Model/RAG
+    evaluation, ...) are not in every region. boto3 surfaces an unsupported
+    operation as an UnknownOperation/"Unknown operation" error. When a check
+    calls such an API in a region that lacks it, that is Not Applicable rather
+    than a security finding or a hard error.
+    """
+    text = str(error)
+    return "UnknownOperation" in text or "Unknown operation" in text
+
+
 def describe_api_error(error: Exception, api_label: str, region: str = "") -> str:
     """
     Build a report-friendly description for an API error raised by a regional
@@ -1742,6 +1756,23 @@ def check_bedrock_knowledge_base_encryption(region: str = "") -> Dict[str, Any]:
                         resolution="Ensure the assessment role can call bedrock:ListKnowledgeBases and bedrock:GetKnowledgeBase for the target account.",
                         reference="https://docs.aws.amazon.com/bedrock/latest/userguide/encryption-kb.html",
                         severity="Informational",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+            elif is_region_unsupported(e):
+                findings["status"] = "N/A"
+                findings["details"] = "Knowledge Bases API not available in this region"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-09",
+                        finding_name="Bedrock Knowledge Base Encryption Check",
+                        finding_details=describe_api_error(
+                            e, "Knowledge Bases API", region
+                        ),
+                        resolution="Amazon Bedrock Knowledge Bases are not available in this region. No action required.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/encryption-kb.html",
+                        severity="Low",
                         status="N/A",
                         region=region,
                     )
@@ -3797,7 +3828,23 @@ def check_bedrock_knowledge_base_kms_encryption(region: str = "") -> Dict[str, A
 
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "")
-            if error_code in ACCESS_DENIED_ERROR_CODES:
+            if is_region_unsupported(e):
+                findings["details"] = "Knowledge Bases API not available in this region"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-20",
+                        finding_name="Knowledge Base Customer-Managed KMS Encryption Check",
+                        finding_details=describe_api_error(
+                            e, "Knowledge Bases API", region
+                        ),
+                        resolution="Amazon Bedrock Knowledge Bases are not available in this region. No action required.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/encryption-kb.html",
+                        severity="Low",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+            elif error_code in ACCESS_DENIED_ERROR_CODES:
                 findings["csv_data"].append(
                     create_finding(
                         check_id="BR-20",
@@ -4070,7 +4117,23 @@ def check_bedrock_agent_action_group_iam(
 
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "")
-            if error_code in ACCESS_DENIED_ERROR_CODES:
+            if is_region_unsupported(e):
+                findings["details"] = "Bedrock Agents API not available in this region"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-21",
+                        finding_name="Agent Action Group IAM Least Privilege Check",
+                        finding_details=describe_api_error(
+                            e, "Bedrock Agents API", region
+                        ),
+                        resolution="Amazon Bedrock Agents are not available in this region. No action required.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/agents.html",
+                        severity="Low",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+            elif error_code in ACCESS_DENIED_ERROR_CODES:
                 findings["csv_data"].append(
                     create_finding(
                         check_id="BR-21",
@@ -4771,7 +4834,25 @@ def check_bedrock_rag_evaluation_jobs(region: str = "") -> Dict[str, Any]:
 
         except ClientError as e:
             error_code = e.response.get("Error", {}).get("Code", "")
-            if error_code in ACCESS_DENIED_ERROR_CODES:
+            if is_region_unsupported(e):
+                findings["details"] = (
+                    "Knowledge Bases / evaluation API not available in this region"
+                )
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-25",
+                        finding_name="RAG Evaluation Jobs Check",
+                        finding_details=describe_api_error(
+                            e, "RAG evaluation API", region
+                        ),
+                        resolution="Amazon Bedrock Knowledge Bases or RAG evaluation are not available in this region. No action required.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/model-evaluation-rag.html",
+                        severity="Low",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+            elif error_code in ACCESS_DENIED_ERROR_CODES:
                 findings["csv_data"].append(
                     create_finding(
                         check_id="BR-25",

--- a/aiml-security-assessment/functions/security/bedrock_assessments/app.py
+++ b/aiml-security-assessment/functions/security/bedrock_assessments/app.py
@@ -3273,20 +3273,39 @@ def check_bedrock_model_evaluations(region: str = "") -> Dict[str, Any]:
             eval_jobs = eval_jobs_response.get("jobSummaries", [])
 
             if not eval_jobs:
-                findings["status"] = "WARN"
-                findings["details"] = "No model evaluation jobs found"
-                findings["csv_data"].append(
-                    create_finding(
-                        check_id="BR-18",
-                        finding_name="Model Evaluation Implementation Check",
-                        finding_details="No Bedrock model evaluation jobs found. Model evaluation helps assess toxicity, accuracy, semantic robustness, and other safety metrics before production deployment.",
-                        resolution="Create model evaluation jobs using Amazon Bedrock Evaluations to assess foundation model performance against safety and quality metrics. Use built-in datasets or custom test sets. Enable LLM-as-a-judge evaluation for comprehensive assessment.",
-                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/evaluation.html",
-                        severity="Medium",
-                        status="Failed",
-                        region=region,
-                    )
+                bedrock_footprint_found = detect_bedrock_regional_footprint(
+                    region=region
                 )
+
+                if bedrock_footprint_found is False:
+                    findings["details"] = "No regional Bedrock resources found"
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-18",
+                            finding_name="Model Evaluation Implementation Check",
+                            finding_details="No regional Bedrock resources found to assess with model evaluation jobs",
+                            resolution="No action required",
+                            reference="https://docs.aws.amazon.com/bedrock/latest/userguide/evaluation.html",
+                            severity="Informational",
+                            status="N/A",
+                            region=region,
+                        )
+                    )
+                else:
+                    findings["status"] = "WARN"
+                    findings["details"] = "No model evaluation jobs found"
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-18",
+                            finding_name="Model Evaluation Implementation Check",
+                            finding_details="No Bedrock model evaluation jobs found. Model evaluation helps assess toxicity, accuracy, semantic robustness, and other safety metrics before production deployment.",
+                            resolution="Create model evaluation jobs using Amazon Bedrock Evaluations to assess foundation model performance against safety and quality metrics. Use built-in datasets or custom test sets. Enable LLM-as-a-judge evaluation for comprehensive assessment.",
+                            reference="https://docs.aws.amazon.com/bedrock/latest/userguide/evaluation.html",
+                            severity="Medium",
+                            status="Failed",
+                            region=region,
+                        )
+                    )
                 return findings
 
             # Analyze evaluation jobs

--- a/aiml-security-assessment/functions/security/bedrock_assessments/app.py
+++ b/aiml-security-assessment/functions/security/bedrock_assessments/app.py
@@ -48,6 +48,27 @@ ACCESS_DENIED_ERROR_CODES = {
 }
 
 
+def is_account_not_authorized(error: Exception) -> bool:
+    """
+    Distinguish an account/feature-gate denial from an IAM-policy denial.
+
+    Both surface as AccessDeniedException, but the cause differs:
+      - IAM gap:        "... is not authorized to perform: <action> because no
+                         identity-based policy allows ..."  -> grant the action.
+      - Account gate:   "Your account is not authorized to invoke this API
+                         operation."  -> the Bedrock feature (e.g. Custom Model
+                         Import, Batch Inference, Model Evaluation) is not enabled
+                         or allow-listed for this account/region. No IAM change
+                         fixes it, so the check is Not Applicable rather than a
+                         finding.
+    """
+    text = str(error)
+    return (
+        "not authorized to invoke this API operation" in text
+        or "account is not authorized" in text
+    )
+
+
 def describe_api_error(error: Exception, api_label: str, region: str = "") -> str:
     """
     Build a report-friendly description for an API error raised by a regional
@@ -3316,6 +3337,24 @@ def check_bedrock_model_evaluations(region: str = "") -> Dict[str, Any]:
                         region=region,
                     )
                 )
+            elif is_account_not_authorized(e):
+                findings["details"] = (
+                    "Model evaluation not enabled for this account/region"
+                )
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-18",
+                        finding_name="Model Evaluation Implementation Check",
+                        finding_details=describe_api_error(
+                            e, "Model evaluation check", region
+                        ),
+                        resolution="Amazon Bedrock model evaluation is not enabled or available for this account in this region. No IAM change is required; enable the feature to assess model evaluation practices.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/evaluation.html",
+                        severity="Low",
+                        status="N/A",
+                        region=region,
+                    )
+                )
             elif error_code in ACCESS_DENIED_ERROR_CODES:
                 findings["csv_data"].append(
                     create_finding(
@@ -5521,6 +5560,24 @@ def check_bedrock_imported_model_kms_encryption(region: str = "") -> Dict[str, A
                         region=region,
                     )
                 )
+            elif is_account_not_authorized(e):
+                findings["details"] = (
+                    "Custom model import not enabled for this account/region"
+                )
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-30",
+                        finding_name="Imported Model Customer-Managed KMS Encryption Check",
+                        finding_details=describe_api_error(
+                            e, "Imported model encryption check", region
+                        ),
+                        resolution="Amazon Bedrock Custom Model Import is not enabled or available for this account in this region. No IAM change is required; the check applies only once model import is in use.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html",
+                        severity="Low",
+                        status="N/A",
+                        region=region,
+                    )
+                )
             elif error_code in ACCESS_DENIED_ERROR_CODES:
                 findings["csv_data"].append(
                     create_finding(
@@ -5671,6 +5728,24 @@ def check_bedrock_batch_inference_output_encryption(
                             e, "Batch inference API", region
                         ),
                         resolution="Batch inference may not be available in all regions",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference.html",
+                        severity="Low",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+            elif is_account_not_authorized(e):
+                findings["details"] = (
+                    "Batch inference not enabled for this account/region"
+                )
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-31",
+                        finding_name="Batch Inference Output Encryption Check",
+                        finding_details=describe_api_error(
+                            e, "Batch inference output encryption check", region
+                        ),
+                        resolution="Amazon Bedrock batch inference is not enabled or available for this account in this region. No IAM change is required; the check applies only once batch inference is in use.",
                         reference="https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference.html",
                         severity="Low",
                         status="N/A",

--- a/aiml-security-assessment/functions/security/bedrock_assessments/app.py
+++ b/aiml-security-assessment/functions/security/bedrock_assessments/app.py
@@ -841,6 +841,43 @@ def has_bedrock_permissions(policy_doc: Any) -> bool:
         return False
 
 
+def _policy_grants_wildcard(policy_doc: Any) -> bool:
+    """
+    Return True if the policy document has an Allow statement granting both
+    Action "*" and Resource "*" (full wildcard access).
+    """
+    try:
+        if isinstance(policy_doc, str):
+            policy_doc = json.loads(policy_doc)
+
+        if not policy_doc:
+            return False
+
+        statements = policy_doc.get("Statement", [])
+        if isinstance(statements, dict):
+            statements = [statements]
+
+        for statement in statements:
+            if statement.get("Effect", "").upper() != "ALLOW":
+                continue
+
+            actions = statement.get("Action", [])
+            if isinstance(actions, str):
+                actions = [actions]
+
+            resources = statement.get("Resource", [])
+            if isinstance(resources, str):
+                resources = [resources]
+
+            if "*" in actions and "*" in resources:
+                return True
+
+        return False
+    except Exception as e:
+        logger.warning(f"Error parsing policy document for wildcard access: {str(e)}")
+        return False
+
+
 def handle_aws_throttling(func, *args, **kwargs):
     """
     Handle AWS API throttling with exponential backoff
@@ -2657,6 +2694,3164 @@ def check_bedrock_agent_roles(permission_cache, region: str = "") -> Dict[str, A
         }
 
 
+def check_bedrock_cross_account_guardrails(region: str = "") -> Dict[str, Any]:
+    """
+    BR-15: Check if organization-level guardrails are configured using AWS Organizations Bedrock policies
+    for centralized safety control enforcement (NEW - April 2026 feature)
+    """
+    logger.debug("Starting check for cross-account guardrails enforcement")
+    try:
+        findings = {
+            "check_name": "Cross-Account Guardrails Enforcement Check",
+            "status": "PASS",
+            "details": "",
+            "csv_data": [],
+        }
+
+        try:
+            orgs_client = boto3.client("organizations", config=boto3_config)
+
+            # Check if running in management account
+            org_info = orgs_client.describe_organization()
+            master_account_id = org_info["Organization"]["MasterAccountId"]
+
+            # Get current account ID
+            sts_client = boto3.client("sts", config=boto3_config)
+            current_account = sts_client.get_caller_identity()["Account"]
+
+            if current_account != master_account_id:
+                findings["details"] = (
+                    "Not running in management account, cannot check organizational policies"
+                )
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-15",
+                        finding_name="Cross-Account Guardrails Enforcement Check",
+                        finding_details="Check must run in AWS Organizations management account to evaluate organizational policies",
+                        resolution="Run assessment in management account to check cross-account guardrails enforcement",
+                        reference="https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_bedrock.html",
+                        severity="Medium",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+                return findings
+
+            # List policy types enabled for the organization. The Amazon Bedrock
+            # policy type (used to enforce guardrails across accounts) is
+            # identified as BEDROCK_POLICY in AWS Organizations.
+            enabled_policy_types = orgs_client.list_roots()["Roots"][0].get(
+                "PolicyTypes", []
+            )
+            bedrock_policy_enabled = any(
+                pt.get("Type") == "BEDROCK_POLICY" and pt.get("Status") == "ENABLED"
+                for pt in enabled_policy_types
+            )
+
+            if not bedrock_policy_enabled:
+                findings["status"] = "WARN"
+                findings["details"] = (
+                    "Bedrock Guardrails policy type is not enabled for the organization"
+                )
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-15",
+                        finding_name="Cross-Account Guardrails Enforcement Check",
+                        finding_details="Bedrock Guardrails policy type is not enabled at the organization level. Cross-account guardrails cannot be enforced without enabling this policy type.",
+                        resolution="Enable Bedrock Guardrails policy type in AWS Organizations to enforce consistent safety controls across all accounts. Use AWS Organizations console or CLI to enable the policy type.",
+                        reference="https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_bedrock.html",
+                        severity="High",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+                return findings
+
+            # Check for Bedrock policies attached to organization roots/OUs/accounts
+            policies_attached = False
+            try:
+                policies = orgs_client.list_policies(Filter="BEDROCK_POLICY")
+                policies_attached = len(policies.get("Policies", [])) > 0
+            except Exception as e:
+                if "UnknownOperation" in str(e) or "Unknown operation" in str(e):
+                    logger.info(
+                        "Bedrock Guardrails policy listing not available in this region"
+                    )
+                    findings["details"] = (
+                        "Bedrock Guardrails organizational policy feature not available in this region"
+                    )
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-15",
+                            finding_name="Cross-Account Guardrails Enforcement Check",
+                            finding_details="Bedrock Guardrails organizational policy API not available in this region",
+                            resolution="This feature may not be available in all regions. Check AWS documentation for regional availability.",
+                            reference="https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_bedrock.html",
+                            severity="Medium",
+                            status="N/A",
+                            region=region,
+                        )
+                    )
+                    return findings
+                raise
+
+            if not policies_attached:
+                findings["status"] = "WARN"
+                findings["details"] = (
+                    "No Bedrock Guardrails policies found at organization level"
+                )
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-15",
+                        finding_name="Cross-Account Guardrails Enforcement Check",
+                        finding_details="Bedrock Guardrails policy type is enabled but no policies are attached. Cross-account guardrails are not being enforced across the organization.",
+                        resolution="Create and attach Bedrock Guardrails policies to the organization root, OUs, or specific accounts to enforce consistent safety controls across all foundation model interactions.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-enforcements.html",
+                        severity="High",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                findings["details"] = (
+                    "Cross-account guardrails enforcement is configured"
+                )
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-15",
+                        finding_name="Cross-Account Guardrails Enforcement Check",
+                        finding_details="Bedrock Guardrails policies are configured at organization level, enabling centralized enforcement of safety controls",
+                        resolution="No action required. Continue monitoring guardrail policy coverage and effectiveness.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-enforcements.html",
+                        severity="Medium",
+                        status="Passed",
+                        region=region,
+                    )
+                )
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code == "AWSOrganizationsNotInUseException":
+                findings["details"] = (
+                    "AWS Organizations is not enabled for this account"
+                )
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-15",
+                        finding_name="Cross-Account Guardrails Enforcement Check",
+                        finding_details="AWS Organizations is not in use. Cross-account guardrails can only be configured in Organizations-enabled accounts.",
+                        resolution="Enable AWS Organizations and configure Bedrock Guardrails policies for centralized multi-account enforcement, or accept single-account guardrail management.",
+                        reference="https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_bedrock.html",
+                        severity="Medium",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+            elif error_code in ACCESS_DENIED_ERROR_CODES:
+                findings["details"] = (
+                    "Insufficient permissions to check organizational policies"
+                )
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-15",
+                        finding_name="Cross-Account Guardrails Enforcement Check",
+                        finding_details=describe_api_error(
+                            e, "Organizations policy check", region
+                        ),
+                        resolution="Grant organizations:DescribeOrganization and organizations:ListPolicies permissions to the assessment role",
+                        reference="https://docs.aws.amazon.com/organizations/latest/userguide/orgs_permissions_overview.html",
+                        severity="Medium",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                raise
+
+        return findings
+
+    except Exception as e:
+        logger.error(
+            f"Error in check_bedrock_cross_account_guardrails: {str(e)}", exc_info=True
+        )
+        return {
+            "check_name": "Cross-Account Guardrails Enforcement Check",
+            "status": "ERROR",
+            "details": f"Error during check: {str(e)}",
+            "csv_data": [
+                create_finding(
+                    check_id="BR-15",
+                    finding_name="Cross-Account Guardrails Enforcement Check",
+                    finding_details=f"Error during check: {str(e)}",
+                    resolution="Investigate error and retry assessment",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-enforcements.html",
+                    severity="High",
+                    status="Failed",
+                    region=region,
+                )
+            ],
+        }
+
+
+def check_bedrock_guardrail_tier(region: str = "") -> Dict[str, Any]:
+    """
+    BR-16: Verify guardrails are using Standard tier (vs Express tier) for enhanced protection
+    """
+    logger.debug("Starting check for Bedrock guardrail tier validation")
+    try:
+        findings = {
+            "check_name": "Guardrail Tier Validation Check",
+            "status": "PASS",
+            "details": "",
+            "csv_data": [],
+        }
+
+        bedrock_client = boto3.client(
+            "bedrock", config=boto3_config, region_name=region
+        )
+
+        try:
+            # List all guardrails
+            guardrails_response = bedrock_client.list_guardrails(maxResults=100)
+            guardrails = guardrails_response.get("guardrails", [])
+
+            if not guardrails:
+                findings["details"] = "No Bedrock guardrails found"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-16",
+                        finding_name="Guardrail Tier Validation Check",
+                        finding_details="No Bedrock guardrails configured in this region",
+                        resolution="Create Bedrock guardrails with Standard tier for enhanced content filtering and protection",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-components.html",
+                        severity="Medium",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+                return findings
+
+            suboptimal_guardrails = []
+            standard_tier_guardrails = []
+
+            for guardrail_summary in guardrails:
+                guardrail_id = guardrail_summary.get("id")
+                guardrail_name = guardrail_summary.get("name", "unknown")
+
+                if not guardrail_id:
+                    continue
+
+                # Get detailed guardrail configuration
+                guardrail_detail = bedrock_client.get_guardrail(
+                    guardrailIdentifier=guardrail_id
+                )
+                guardrail_config = guardrail_detail.get("guardrail", guardrail_detail)
+
+                # The content-filter tier is reported under
+                # contentPolicy.tier.tierName. Valid values are CLASSIC and
+                # STANDARD; STANDARD is the more robust tier. When a guardrail has
+                # no content policy the field is absent, so default to CLASSIC
+                # (the baseline) rather than assuming the enhanced tier.
+                content_policy = guardrail_config.get("contentPolicy", {})
+                tier = content_policy.get("tier", {}).get("tierName", "CLASSIC")
+
+                if tier != "STANDARD":
+                    suboptimal_guardrails.append(
+                        {"name": guardrail_name, "id": guardrail_id, "tier": tier}
+                    )
+                else:
+                    standard_tier_guardrails.append(guardrail_name)
+
+            if suboptimal_guardrails:
+                findings["status"] = "WARN"
+                findings["details"] = (
+                    f"Found {len(suboptimal_guardrails)} guardrails not using STANDARD tier"
+                )
+
+                for gr in suboptimal_guardrails:
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-16",
+                            finding_name="Guardrail Tier Validation Check",
+                            finding_details=f"Guardrail '{gr['name']}' (ID: {gr['id']}) is using the '{gr['tier']}' content-filter tier instead of 'STANDARD'. The STANDARD tier provides more robust content filtering and broader language support than the CLASSIC tier.",
+                            resolution="Update the guardrail to use the STANDARD content-filter tier for improved contextual understanding, better prompt attack filtering (distinguishing jailbreaks from prompt injection), and broader language support. The STANDARD tier requires cross-Region inference. Review pricing implications before upgrading.",
+                            reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-components.html",
+                            severity="Medium",
+                            status="Failed",
+                            region=region,
+                        )
+                    )
+
+            if standard_tier_guardrails:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-16",
+                        finding_name="Guardrail Tier Validation Check",
+                        finding_details=f"{len(standard_tier_guardrails)} guardrails are using the STANDARD content-filter tier with enhanced protection capabilities",
+                        resolution="No action required. Continue monitoring guardrail effectiveness.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html",
+                        severity="Low",
+                        status="Passed",
+                        region=region,
+                    )
+                )
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in ACCESS_DENIED_ERROR_CODES:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-16",
+                        finding_name="Guardrail Tier Validation Check",
+                        finding_details=describe_api_error(
+                            e, "Guardrail tier check", region
+                        ),
+                        resolution="Grant bedrock:ListGuardrails and bedrock:GetGuardrail permissions",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html",
+                        severity="Medium",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                raise
+
+        return findings
+
+    except Exception as e:
+        logger.error(f"Error in check_bedrock_guardrail_tier: {str(e)}", exc_info=True)
+        return {
+            "check_name": "Guardrail Tier Validation Check",
+            "status": "ERROR",
+            "details": f"Error during check: {str(e)}",
+            "csv_data": [
+                create_finding(
+                    check_id="BR-16",
+                    finding_name="Guardrail Tier Validation Check",
+                    finding_details=f"Error during check: {str(e)}",
+                    resolution="Investigate error and retry assessment",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html",
+                    severity="Medium",
+                    status="Failed",
+                    region=region,
+                )
+            ],
+        }
+
+
+def check_bedrock_custom_model_kms_encryption(region: str = "") -> Dict[str, Any]:
+    """
+    BR-17: Verify fine-tuned/customized models use customer-managed KMS keys instead of AWS-owned keys
+    Note: This extends the existing check_bedrock_custom_model_encryption (BR-11) to specifically verify KMS key type
+    """
+    logger.debug("Starting check for custom model KMS encryption")
+    try:
+        findings = {
+            "check_name": "Custom Model Customer-Managed KMS Encryption Check",
+            "status": "PASS",
+            "details": "",
+            "csv_data": [],
+        }
+
+        bedrock_client = boto3.client(
+            "bedrock", config=boto3_config, region_name=region
+        )
+
+        try:
+            # Get custom models using paginator
+            paginator = bedrock_client.get_paginator("list_custom_models")
+            custom_models = []
+            for page in paginator.paginate():
+                custom_models.extend(page.get("modelSummaries", []))
+
+            if not custom_models:
+                findings["details"] = "No custom models found"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-17",
+                        finding_name="Custom Model Customer-Managed KMS Encryption Check",
+                        finding_details="No custom (fine-tuned) Bedrock models found in this region",
+                        resolution="When creating custom models, specify a customer-managed KMS key for encryption to maintain control over encryption keys",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/encryption-custom-job.html",
+                        severity="High",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+                return findings
+
+            models_with_aws_keys = []
+            models_with_customer_keys = []
+            models_unknown = []
+
+            for model in custom_models:
+                model_arn = model.get("modelArn")
+                model_name = model.get("modelName", "unknown")
+
+                # Get model details to check encryption
+                try:
+                    model_detail = bedrock_client.get_custom_model(
+                        modelIdentifier=model_arn
+                    )
+
+                    # GetCustomModel reports the encryption key as modelKmsKeyArn.
+                    # When absent, the model is encrypted with an AWS-owned key.
+                    kms_key_id = model_detail.get("modelKmsKeyArn")
+
+                    if not kms_key_id:
+                        # No KMS key specified = AWS-owned key
+                        models_with_aws_keys.append(
+                            {"name": model_name, "arn": model_arn}
+                        )
+                    elif kms_key_id.startswith("arn:aws:kms"):
+                        # Customer-managed KMS key
+                        models_with_customer_keys.append(model_name)
+                    else:
+                        # Unknown key format
+                        models_unknown.append(model_name)
+
+                except ClientError as detail_error:
+                    error_code = detail_error.response.get("Error", {}).get("Code", "")
+                    if error_code not in ACCESS_DENIED_ERROR_CODES:
+                        logger.warning(
+                            f"Could not get details for model {model_name}: {error_code}"
+                        )
+                    models_unknown.append(model_name)
+
+            if models_with_aws_keys:
+                findings["status"] = "WARN"
+                findings["details"] = (
+                    f"Found {len(models_with_aws_keys)} custom models using AWS-owned keys"
+                )
+
+                for model_info in models_with_aws_keys:
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-17",
+                            finding_name="Custom Model Customer-Managed KMS Encryption Check",
+                            finding_details=f"Custom model '{model_info['name']}' uses AWS-owned encryption keys instead of customer-managed KMS keys. This limits your control over key rotation, access policies, and audit trail.",
+                            resolution="When creating new custom models, specify a customer-managed KMS key using the customizationConfig.kmsKeyArn parameter. For existing models, consider retraining with customer-managed KMS encryption. Ensure KMS key grants allow Amazon Bedrock service access.",
+                            reference="https://docs.aws.amazon.com/bedrock/latest/userguide/encryption-custom-job.html",
+                            severity="High",
+                            status="Failed",
+                            region=region,
+                        )
+                    )
+
+            if models_with_customer_keys:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-17",
+                        finding_name="Custom Model Customer-Managed KMS Encryption Check",
+                        finding_details=f"{len(models_with_customer_keys)} custom models are using customer-managed KMS keys for encryption",
+                        resolution="No action required. Continue using customer-managed keys for new custom models.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/encryption-custom-job.html",
+                        severity="Medium",
+                        status="Passed",
+                        region=region,
+                    )
+                )
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in ACCESS_DENIED_ERROR_CODES:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-17",
+                        finding_name="Custom Model Customer-Managed KMS Encryption Check",
+                        finding_details=describe_api_error(
+                            e, "Custom model encryption check", region
+                        ),
+                        resolution="Grant bedrock:ListCustomModels and bedrock:GetCustomModel permissions",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html",
+                        severity="High",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                raise
+
+        return findings
+
+    except Exception as e:
+        logger.error(
+            f"Error in check_bedrock_custom_model_kms_encryption: {str(e)}",
+            exc_info=True,
+        )
+        return {
+            "check_name": "Custom Model Customer-Managed KMS Encryption Check",
+            "status": "ERROR",
+            "details": f"Error during check: {str(e)}",
+            "csv_data": [
+                create_finding(
+                    check_id="BR-17",
+                    finding_name="Custom Model Customer-Managed KMS Encryption Check",
+                    finding_details=f"Error during check: {str(e)}",
+                    resolution="Investigate error and retry assessment",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/encryption-custom-job.html",
+                    severity="High",
+                    status="Failed",
+                    region=region,
+                )
+            ],
+        }
+
+
+def check_bedrock_model_evaluations(region: str = "") -> Dict[str, Any]:
+    """
+    BR-18: Check if model evaluation jobs exist for foundation models to assess safety metrics
+    """
+    logger.debug("Starting check for Bedrock model evaluation implementation")
+    try:
+        findings = {
+            "check_name": "Model Evaluation Implementation Check",
+            "status": "PASS",
+            "details": "",
+            "csv_data": [],
+        }
+
+        bedrock_client = boto3.client(
+            "bedrock", config=boto3_config, region_name=region
+        )
+
+        try:
+            # List model evaluation jobs
+            eval_jobs_response = bedrock_client.list_evaluation_jobs(maxResults=100)
+            eval_jobs = eval_jobs_response.get("jobSummaries", [])
+
+            if not eval_jobs:
+                findings["status"] = "WARN"
+                findings["details"] = "No model evaluation jobs found"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-18",
+                        finding_name="Model Evaluation Implementation Check",
+                        finding_details="No Bedrock model evaluation jobs found. Model evaluation helps assess toxicity, accuracy, semantic robustness, and other safety metrics before production deployment.",
+                        resolution="Create model evaluation jobs using Amazon Bedrock Evaluations to assess foundation model performance against safety and quality metrics. Use built-in datasets or custom test sets. Enable LLM-as-a-judge evaluation for comprehensive assessment.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/evaluation.html",
+                        severity="Medium",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+                return findings
+
+            # Analyze evaluation jobs
+            recent_evaluations = []
+            thirty_days_ago = datetime.now(timezone.utc) - timedelta(days=30)
+
+            for job in eval_jobs:
+                job_name = job.get("jobName", "unknown")
+                job_status = job.get("status", "unknown")
+                creation_time = job.get("creationTime")
+
+                # Check if evaluation is recent (within 30 days)
+                is_recent = False
+                if creation_time:
+                    if isinstance(creation_time, str):
+                        try:
+                            creation_time = datetime.fromisoformat(
+                                creation_time.replace("Z", "+00:00")
+                            )
+                        except ValueError:
+                            pass
+                    if isinstance(creation_time, datetime):
+                        is_recent = creation_time >= thirty_days_ago
+
+                if is_recent and job_status == "Completed":
+                    recent_evaluations.append(job_name)
+
+            findings["details"] = (
+                f"Found {len(eval_jobs)} model evaluation jobs, {len(recent_evaluations)} recent"
+            )
+
+            if recent_evaluations:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-18",
+                        finding_name="Model Evaluation Implementation Check",
+                        finding_details=f"Found {len(recent_evaluations)} model evaluation jobs completed in the last 30 days. Regular evaluation helps maintain model quality and safety standards.",
+                        resolution="Continue regular model evaluations. Consider implementing automated evaluation pipelines for continuous model validation. Review evaluation results for safety metrics including toxicity and bias.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/evaluation.html",
+                        severity="Low",
+                        status="Passed",
+                        region=region,
+                    )
+                )
+            else:
+                findings["status"] = "WARN"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-18",
+                        finding_name="Model Evaluation Implementation Check",
+                        finding_details=f"Found {len(eval_jobs)} total model evaluation jobs, but none completed in the last 30 days. Regular evaluation is recommended for production models.",
+                        resolution="Schedule regular model evaluation runs to assess ongoing model performance and safety. Configure evaluations to include responsible AI metrics like toxicity, accuracy, and robustness.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/evaluation.html",
+                        severity="Medium",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            error_msg = str(e)
+
+            if "UnknownOperation" in error_msg or "Unknown operation" in error_msg:
+                findings["details"] = (
+                    "Model evaluation API not available in this region"
+                )
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-18",
+                        finding_name="Model Evaluation Implementation Check",
+                        finding_details=describe_api_error(
+                            e, "Model evaluation API", region
+                        ),
+                        resolution="Model evaluation may not be available in all regions. Check AWS documentation for regional availability.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/evaluation.html",
+                        severity="Low",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+            elif error_code in ACCESS_DENIED_ERROR_CODES:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-18",
+                        finding_name="Model Evaluation Implementation Check",
+                        finding_details=describe_api_error(
+                            e, "Model evaluation check", region
+                        ),
+                        resolution="Grant bedrock:ListEvaluationJobs permission to assess model evaluation practices",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html",
+                        severity="Medium",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                raise
+
+        return findings
+
+    except Exception as e:
+        logger.error(
+            f"Error in check_bedrock_model_evaluations: {str(e)}", exc_info=True
+        )
+        return {
+            "check_name": "Model Evaluation Implementation Check",
+            "status": "ERROR",
+            "details": f"Error during check: {str(e)}",
+            "csv_data": [
+                create_finding(
+                    check_id="BR-18",
+                    finding_name="Model Evaluation Implementation Check",
+                    finding_details=f"Error during check: {str(e)}",
+                    resolution="Investigate error and retry assessment",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/evaluation.html",
+                    severity="Medium",
+                    status="Failed",
+                    region=region,
+                )
+            ],
+        }
+
+
+def check_bedrock_prompt_flow_validation(region: str = "") -> Dict[str, Any]:
+    """
+    BR-19: Verify Bedrock Agents prompt flows are validated before deployment
+    """
+    logger.debug("Starting check for Bedrock prompt flow validation")
+    try:
+        findings = {
+            "check_name": "Prompt Flow Validation Check",
+            "status": "PASS",
+            "details": "",
+            "csv_data": [],
+        }
+
+        bedrock_agent_client = boto3.client(
+            "bedrock-agent", config=boto3_config, region_name=region
+        )
+
+        try:
+            # List all flows
+            flows_response = bedrock_agent_client.list_flows(maxResults=100)
+            flows = flows_response.get("flowSummaries", [])
+
+            if not flows:
+                findings["details"] = "No Bedrock prompt flows found"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-19",
+                        finding_name="Prompt Flow Validation Check",
+                        finding_details="No Bedrock prompt flows configured in this region",
+                        resolution="When creating prompt flows, use the ValidateFlowDefinition API to validate flow definitions before deployment",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/flows.html",
+                        severity="Medium",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+                return findings
+
+            unvalidated_flows = []
+            validated_flows = []
+
+            for flow_summary in flows:
+                flow_id = flow_summary.get("id")
+                flow_name = flow_summary.get("name", "unknown")
+                flow_status = flow_summary.get("status", "unknown")
+
+                if not flow_id:
+                    continue
+
+                # Get detailed flow configuration
+                try:
+                    flow_detail = bedrock_agent_client.get_flow(flowIdentifier=flow_id)
+                    flow_info = flow_detail.get("flow", flow_detail)
+
+                    # GetFlow returns a `validations` array describing problems
+                    # found when the flow was last prepared. Treat any validation
+                    # entry with ERROR severity as a failed validation. A flow that
+                    # is Prepared/Published with no error-level validations is
+                    # considered validated.
+                    validations = flow_info.get("validations", [])
+                    error_validations = [
+                        v
+                        for v in validations
+                        if str(v.get("severity", "")).upper() == "ERROR"
+                    ]
+
+                    if error_validations:
+                        messages = "; ".join(
+                            v.get("message", "unknown") for v in error_validations[:5]
+                        )
+                        unvalidated_flows.append(
+                            {
+                                "name": flow_name,
+                                "id": flow_id,
+                                "status": flow_status,
+                                "errors": messages,
+                            }
+                        )
+                    elif flow_status in ["Prepared", "Published"]:
+                        validated_flows.append(flow_name)
+                    else:
+                        # No error-level validations, but the flow has not been
+                        # prepared/published, so it has not been validated for
+                        # deployment.
+                        unvalidated_flows.append(
+                            {
+                                "name": flow_name,
+                                "id": flow_id,
+                                "status": flow_status,
+                                "errors": "",
+                            }
+                        )
+
+                except ClientError as detail_error:
+                    error_code = detail_error.response.get("Error", {}).get("Code", "")
+                    if error_code not in ACCESS_DENIED_ERROR_CODES:
+                        logger.warning(
+                            f"Could not get details for flow {flow_name}: {error_code}"
+                        )
+
+            if unvalidated_flows:
+                findings["status"] = "WARN"
+                findings["details"] = (
+                    f"Found {len(unvalidated_flows)} flows that may not be validated"
+                )
+
+                for flow in unvalidated_flows:
+                    if flow.get("errors"):
+                        detail = (
+                            f"Prompt flow '{flow['name']}' (ID: {flow['id']}) has "
+                            f"validation errors: {flow['errors']}. Unvalidated flows "
+                            "can lead to runtime errors or unexpected behavior."
+                        )
+                    else:
+                        detail = (
+                            f"Prompt flow '{flow['name']}' (ID: {flow['id']}) has "
+                            f"status '{flow['status']}' and has not been validated for "
+                            "deployment. Unvalidated flows can lead to runtime errors "
+                            "or unexpected behavior."
+                        )
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-19",
+                            finding_name="Prompt Flow Validation Check",
+                            finding_details=detail,
+                            resolution="Use the ValidateFlowDefinition API to validate the flow definition before preparing or publishing. Fix any validation errors before deployment. Ensure all nodes, connections, and configurations are correct.",
+                            reference="https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_ValidateFlowDefinition.html",
+                            severity="Medium",
+                            status="Failed",
+                            region=region,
+                        )
+                    )
+
+            if validated_flows:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-19",
+                        finding_name="Prompt Flow Validation Check",
+                        finding_details=f"{len(validated_flows)} prompt flows are validated and prepared for deployment",
+                        resolution="No action required. Continue validating flows before deployment.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/flows.html",
+                        severity="Low",
+                        status="Passed",
+                        region=region,
+                    )
+                )
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            error_msg = str(e)
+
+            if "UnknownOperation" in error_msg or "Unknown operation" in error_msg:
+                findings["details"] = "Prompt flows API not available in this region"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-19",
+                        finding_name="Prompt Flow Validation Check",
+                        finding_details=describe_api_error(
+                            e, "Prompt flows API", region
+                        ),
+                        resolution="Bedrock prompt flows may not be available in all regions",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/flows.html",
+                        severity="Low",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+            elif error_code in ACCESS_DENIED_ERROR_CODES:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-19",
+                        finding_name="Prompt Flow Validation Check",
+                        finding_details=describe_api_error(
+                            e, "Prompt flow check", region
+                        ),
+                        resolution="Grant bedrock-agent:ListFlows and bedrock-agent:GetFlow permissions",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html",
+                        severity="Medium",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                raise
+
+        return findings
+
+    except Exception as e:
+        logger.error(
+            f"Error in check_bedrock_prompt_flow_validation: {str(e)}", exc_info=True
+        )
+        return {
+            "check_name": "Prompt Flow Validation Check",
+            "status": "ERROR",
+            "details": f"Error during check: {str(e)}",
+            "csv_data": [
+                create_finding(
+                    check_id="BR-19",
+                    finding_name="Prompt Flow Validation Check",
+                    finding_details=f"Error during check: {str(e)}",
+                    resolution="Investigate error and retry assessment",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/flows.html",
+                    severity="Medium",
+                    status="Failed",
+                    region=region,
+                )
+            ],
+        }
+
+
+def check_bedrock_knowledge_base_kms_encryption(region: str = "") -> Dict[str, Any]:
+    """
+    BR-20: Verify Knowledge Base vector stores use customer-managed KMS keys (extends BR-09)
+    """
+    logger.debug("Starting check for Knowledge Base customer-managed KMS encryption")
+    try:
+        findings = {
+            "check_name": "Knowledge Base Customer-Managed KMS Encryption Check",
+            "status": "PASS",
+            "details": "",
+            "csv_data": [],
+        }
+
+        bedrock_agent_client = boto3.client(
+            "bedrock-agent", config=boto3_config, region_name=region
+        )
+
+        try:
+            # List all knowledge bases
+            kb_response = bedrock_agent_client.list_knowledge_bases(maxResults=100)
+            knowledge_bases = kb_response.get("knowledgeBaseSummaries", [])
+
+            if not knowledge_bases:
+                findings["details"] = "No Bedrock knowledge bases found"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-20",
+                        finding_name="Knowledge Base Customer-Managed KMS Encryption Check",
+                        finding_details="No Bedrock knowledge bases found in this region",
+                        resolution="When creating knowledge bases, specify customer-managed KMS keys for both vector store and data source encryption",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/encryption-kb.html",
+                        severity="High",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+                return findings
+
+            kbs_with_aws_keys = []
+            kbs_with_customer_keys = []
+            kbs_storage_layer_review = []
+            kbs_indeterminate = []
+
+            for kb_summary in knowledge_bases:
+                kb_id = kb_summary.get("knowledgeBaseId")
+                kb_name = kb_summary.get("name", "unknown")
+
+                if not kb_id:
+                    continue
+
+                # Get detailed KB configuration
+                try:
+                    kb_detail = bedrock_agent_client.get_knowledge_base(
+                        knowledgeBaseId=kb_id
+                    )
+                    kb_config = kb_detail.get("knowledgeBase", {})
+
+                    # The KB `type` (VECTOR | KENDRA | SQL | MANAGED) is the
+                    # authoritative discriminator and is present in every SDK
+                    # version. Only a MANAGED knowledge base exposes the
+                    # customer-managed KMS key directly on the KB, under
+                    # knowledgeBaseConfiguration.managedKnowledgeBaseConfiguration.
+                    # serverSideEncryptionConfiguration.kmsKeyArn. For VECTOR / SQL /
+                    # KENDRA stores the encryption key lives on the underlying
+                    # storage resource and cannot be read from this API, so those
+                    # are flagged for manual review rather than reported as failures.
+                    kb_configuration = kb_config.get("knowledgeBaseConfiguration", {})
+                    kb_type = kb_configuration.get("type", "")
+                    managed_config = kb_configuration.get(
+                        "managedKnowledgeBaseConfiguration"
+                    )
+                    storage_config = kb_config.get("storageConfiguration", {})
+                    storage_type = storage_config.get("type") or kb_type or "Unknown"
+
+                    is_managed_type = kb_type == "MANAGED"
+
+                    if is_managed_type and managed_config is None:
+                        # The KB is MANAGED but the managedKnowledgeBaseConfiguration
+                        # block is absent from the response. This happens when the
+                        # bundled botocore model predates the field (added in
+                        # botocore 1.43.32); botocore silently strips unmodeled
+                        # fields. Surface as indeterminate rather than failing or
+                        # passing on incomplete data.
+                        kbs_indeterminate.append({"name": kb_name, "id": kb_id})
+                    elif managed_config is not None:
+                        sse_config = managed_config.get(
+                            "serverSideEncryptionConfiguration", {}
+                        )
+                        kms_key_arn = sse_config.get("kmsKeyArn")
+
+                        if kms_key_arn and kms_key_arn.startswith("arn:aws:kms"):
+                            kbs_with_customer_keys.append(kb_name)
+                        else:
+                            kbs_with_aws_keys.append(
+                                {
+                                    "name": kb_name,
+                                    "id": kb_id,
+                                    "storage_type": "Managed (Amazon Bedrock)",
+                                }
+                            )
+                    else:
+                        # Custom vector store (VECTOR / SQL / KENDRA): encryption is
+                        # managed at the storage layer and cannot be validated from
+                        # the KB API.
+                        kbs_storage_layer_review.append(
+                            {
+                                "name": kb_name,
+                                "id": kb_id,
+                                "storage_type": storage_type,
+                            }
+                        )
+
+                except ClientError as detail_error:
+                    error_code = detail_error.response.get("Error", {}).get("Code", "")
+                    if error_code not in ACCESS_DENIED_ERROR_CODES:
+                        logger.warning(
+                            f"Could not get details for KB {kb_name}: {error_code}"
+                        )
+
+            if kbs_with_aws_keys:
+                findings["status"] = "WARN"
+                findings["details"] = (
+                    f"Found {len(kbs_with_aws_keys)} managed knowledge bases without a customer-managed KMS key"
+                )
+
+                for kb in kbs_with_aws_keys:
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-20",
+                            finding_name="Knowledge Base Customer-Managed KMS Encryption Check",
+                            finding_details=f"Managed knowledge base '{kb['name']}' (ID: {kb['id']}) does not have a customer-managed KMS key configured and is encrypted with an AWS-owned key. This limits control over key rotation, access policies, and audit trails.",
+                            resolution="When creating or updating a managed knowledge base, specify a customer-managed KMS key ARN under knowledgeBaseConfiguration.managedKnowledgeBaseConfiguration.serverSideEncryptionConfiguration.kmsKeyArn. Ensure the KMS key policy allows Amazon Bedrock service access.",
+                            reference="https://docs.aws.amazon.com/bedrock/latest/userguide/encryption-kb.html",
+                            severity="High",
+                            status="Failed",
+                            region=region,
+                        )
+                    )
+
+            if kbs_storage_layer_review:
+                if findings["status"] == "PASS":
+                    findings["status"] = "WARN"
+                for kb in kbs_storage_layer_review:
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-20",
+                            finding_name="Knowledge Base Customer-Managed KMS Encryption Review",
+                            finding_details=f"Knowledge base '{kb['name']}' (ID: {kb['id']}) uses '{kb['storage_type']}' storage. The vector-store encryption key is managed at the storage layer and cannot be validated from the Knowledge Base API. Verify customer-managed KMS encryption on the underlying store.",
+                            resolution="1. For OpenSearch Serverless: verify the collection uses a customer-managed KMS key\n2. For Amazon RDS/Aurora: verify KMS encryption on the database\n3. For third-party stores (Pinecone, Redis, MongoDB): verify the provider's encryption configuration\n4. Verify the customer-managed KMS key used for transient data during ingestion",
+                            reference="https://docs.aws.amazon.com/bedrock/latest/userguide/encryption-kb.html",
+                            severity="Informational",
+                            status="N/A",
+                            region=region,
+                        )
+                    )
+
+            if kbs_indeterminate:
+                if findings["status"] == "PASS":
+                    findings["status"] = "WARN"
+                for kb in kbs_indeterminate:
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-20",
+                            finding_name="Knowledge Base Customer-Managed KMS Encryption Review",
+                            finding_details=f"Knowledge base '{kb['name']}' (ID: {kb['id']}) is a MANAGED knowledge base, but its encryption configuration could not be read from the API response. This typically means the deployed AWS SDK (botocore) predates the managedKnowledgeBaseConfiguration field (added in botocore 1.43.32) and silently dropped it. Customer-managed KMS encryption could not be confirmed.",
+                            resolution="Upgrade the function's bundled boto3/botocore to 1.43.32 or later so the managed knowledge base encryption configuration is returned, then re-run the assessment. Meanwhile, verify the customer-managed KMS key in the Amazon Bedrock console.",
+                            reference="https://docs.aws.amazon.com/bedrock/latest/userguide/encryption-kb.html",
+                            severity="Informational",
+                            status="N/A",
+                            region=region,
+                        )
+                    )
+
+            if kbs_with_customer_keys:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-20",
+                        finding_name="Knowledge Base Customer-Managed KMS Encryption Check",
+                        finding_details=f"{len(kbs_with_customer_keys)} managed knowledge bases are using customer-managed KMS keys",
+                        resolution="No action required. Continue using customer-managed keys for new knowledge bases.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/encryption-kb.html",
+                        severity="Medium",
+                        status="Passed",
+                        region=region,
+                    )
+                )
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in ACCESS_DENIED_ERROR_CODES:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-20",
+                        finding_name="Knowledge Base Customer-Managed KMS Encryption Check",
+                        finding_details=describe_api_error(
+                            e, "Knowledge base encryption check", region
+                        ),
+                        resolution="Grant bedrock-agent:ListKnowledgeBases and bedrock-agent:GetKnowledgeBase permissions",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html",
+                        severity="High",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                raise
+
+        return findings
+
+    except Exception as e:
+        logger.error(
+            f"Error in check_bedrock_knowledge_base_kms_encryption: {str(e)}",
+            exc_info=True,
+        )
+        return {
+            "check_name": "Knowledge Base Customer-Managed KMS Encryption Check",
+            "status": "ERROR",
+            "details": f"Error during check: {str(e)}",
+            "csv_data": [
+                create_finding(
+                    check_id="BR-20",
+                    finding_name="Knowledge Base Customer-Managed KMS Encryption Check",
+                    finding_details=f"Error during check: {str(e)}",
+                    resolution="Investigate error and retry assessment",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/encryption-kb.html",
+                    severity="High",
+                    status="Failed",
+                    region=region,
+                )
+            ],
+        }
+
+
+def check_bedrock_agent_action_group_iam(
+    region: str = "", permission_cache: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """
+    BR-21: Check if Bedrock Agent action groups use scoped Lambda execution roles (extends BR-08)
+    """
+    logger.debug("Starting check for Bedrock Agent action group IAM least privilege")
+
+    if permission_cache is None:
+        permission_cache = {}
+
+    try:
+        findings = {
+            "check_name": "Agent Action Group IAM Least Privilege Check",
+            "status": "PASS",
+            "details": "",
+            "csv_data": [],
+        }
+
+        bedrock_agent_client = boto3.client(
+            "bedrock-agent", config=boto3_config, region_name=region
+        )
+        lambda_client = boto3.client("lambda", config=boto3_config, region_name=region)
+
+        try:
+            # List all agents
+            agents_response = bedrock_agent_client.list_agents(maxResults=100)
+            agents = agents_response.get("agentSummaries", [])
+
+            if not agents:
+                findings["details"] = "No Bedrock agents found"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-21",
+                        finding_name="Agent Action Group IAM Least Privilege Check",
+                        finding_details="No Bedrock agents configured in this region",
+                        resolution="When creating agents with action groups, ensure Lambda execution roles follow least privilege principles",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/agents-security.html",
+                        severity="High",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+                return findings
+
+            overly_permissive_lambdas = []
+            compliant_lambdas = []
+
+            for agent_summary in agents:
+                agent_id = agent_summary.get("agentId")
+                agent_name = agent_summary.get("agentName", "unknown")
+
+                if not agent_id:
+                    continue
+
+                try:
+                    # Get agent action groups
+                    action_groups_response = (
+                        bedrock_agent_client.list_agent_action_groups(
+                            agentId=agent_id, agentVersion="DRAFT", maxResults=100
+                        )
+                    )
+                    action_groups = action_groups_response.get(
+                        "actionGroupSummaries", []
+                    )
+
+                    for action_group in action_groups:
+                        # Get action group details
+                        action_group_id = action_group.get("actionGroupId")
+                        action_group_name = action_group.get(
+                            "actionGroupName", "unknown"
+                        )
+
+                        if not action_group_id:
+                            continue
+
+                        try:
+                            ag_detail = bedrock_agent_client.get_agent_action_group(
+                                agentId=agent_id,
+                                agentVersion="DRAFT",
+                                actionGroupId=action_group_id,
+                            )
+                            ag_config = ag_detail.get("agentActionGroup", {})
+
+                            # Get Lambda function ARN if configured
+                            action_group_executor = ag_config.get(
+                                "actionGroupExecutor", {}
+                            )
+                            lambda_arn = action_group_executor.get("lambda")
+
+                            if lambda_arn:
+                                # Extract function name from ARN
+                                function_name = (
+                                    lambda_arn.split(":")[-1]
+                                    if ":" in lambda_arn
+                                    else lambda_arn
+                                )
+
+                                try:
+                                    # Get Lambda function configuration
+                                    lambda_config = lambda_client.get_function(
+                                        FunctionName=function_name
+                                    )
+                                    role_arn = lambda_config.get(
+                                        "Configuration", {}
+                                    ).get("Role")
+
+                                    if role_arn:
+                                        # Check if role has overly broad permissions
+                                        role_name = role_arn.split("/")[-1]
+
+                                        # Check permission cache for this role. Each
+                                        # policy entry is a dict {"name", "document"},
+                                        # so inspect the policy name rather than the
+                                        # dict itself.
+                                        role_perms = permission_cache.get(
+                                            "role_permissions", {}
+                                        ).get(role_name, {})
+                                        attached_policies = role_perms.get(
+                                            "attached_policies", []
+                                        )
+                                        inline_policies = role_perms.get(
+                                            "inline_policies", []
+                                        )
+
+                                        # Check for overly permissive managed policies
+                                        # by policy name.
+                                        has_admin_access = any(
+                                            p.get("name") == "AdministratorAccess"
+                                            for p in attached_policies
+                                        )
+                                        has_full_access = any(
+                                            "FullAccess" in (p.get("name") or "")
+                                            for p in attached_policies
+                                        )
+                                        # Check inline policy documents for an Allow on
+                                        # Action "*" / Resource "*" (wildcard access).
+                                        has_star_resource = any(
+                                            _policy_grants_wildcard(p.get("document"))
+                                            for p in inline_policies
+                                        )
+
+                                        if (
+                                            has_admin_access
+                                            or has_full_access
+                                            or has_star_resource
+                                        ):
+                                            if has_admin_access:
+                                                issue = "AdministratorAccess"
+                                            elif has_full_access:
+                                                issue = "a *FullAccess managed policy"
+                                            else:
+                                                issue = (
+                                                    "an inline policy granting wildcard "
+                                                    'Action/Resource ("*")'
+                                                )
+                                            overly_permissive_lambdas.append(
+                                                {
+                                                    "agent_name": agent_name,
+                                                    "action_group": action_group_name,
+                                                    "function_name": function_name,
+                                                    "role_name": role_name,
+                                                    "issue": issue,
+                                                }
+                                            )
+                                        else:
+                                            compliant_lambdas.append(function_name)
+
+                                except ClientError as lambda_error:
+                                    error_code = lambda_error.response.get(
+                                        "Error", {}
+                                    ).get("Code", "")
+                                    if error_code not in ACCESS_DENIED_ERROR_CODES:
+                                        logger.warning(
+                                            f"Could not get Lambda config for {function_name}: {error_code}"
+                                        )
+
+                        except ClientError as ag_error:
+                            error_code = ag_error.response.get("Error", {}).get(
+                                "Code", ""
+                            )
+                            if error_code not in ACCESS_DENIED_ERROR_CODES:
+                                logger.warning(
+                                    f"Could not get action group details: {error_code}"
+                                )
+
+                except ClientError as list_error:
+                    error_code = list_error.response.get("Error", {}).get("Code", "")
+                    if error_code not in ACCESS_DENIED_ERROR_CODES:
+                        logger.warning(
+                            f"Could not list action groups for agent {agent_name}: {error_code}"
+                        )
+
+            if overly_permissive_lambdas:
+                findings["status"] = "WARN"
+                findings["details"] = (
+                    f"Found {len(overly_permissive_lambdas)} Lambda functions with overly permissive IAM roles"
+                )
+
+                for lambda_info in overly_permissive_lambdas:
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-21",
+                            finding_name="Agent Action Group IAM Least Privilege Check",
+                            finding_details=f"Lambda function '{lambda_info['function_name']}' used by agent '{lambda_info['agent_name']}' action group '{lambda_info['action_group']}' has role '{lambda_info['role_name']}' with {lambda_info['issue']}. This violates least privilege principles.",
+                            resolution="Update the Lambda execution role to use scoped permissions. Remove AdministratorAccess and FullAccess policies. Grant only the specific AWS service permissions needed for the action group's operations. Use Resource-based policies to scope permissions to specific resources.",
+                            reference="https://docs.aws.amazon.com/bedrock/latest/userguide/agents-security.html",
+                            severity="High",
+                            status="Failed",
+                            region=region,
+                        )
+                    )
+
+            if compliant_lambdas:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-21",
+                        finding_name="Agent Action Group IAM Least Privilege Check",
+                        finding_details=f"{len(compliant_lambdas)} Lambda functions are using scoped IAM roles",
+                        resolution="No action required. Continue using least privilege IAM roles for action group Lambda functions.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/agents-security.html",
+                        severity="Medium",
+                        status="Passed",
+                        region=region,
+                    )
+                )
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in ACCESS_DENIED_ERROR_CODES:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-21",
+                        finding_name="Agent Action Group IAM Least Privilege Check",
+                        finding_details=describe_api_error(
+                            e, "Agent action group IAM check", region
+                        ),
+                        resolution="Grant bedrock-agent:ListAgents, bedrock-agent:ListAgentActionGroups, bedrock-agent:GetAgentActionGroup, and lambda:GetFunction permissions",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html",
+                        severity="High",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                raise
+
+        return findings
+
+    except Exception as e:
+        logger.error(
+            f"Error in check_bedrock_agent_action_group_iam: {str(e)}", exc_info=True
+        )
+        return {
+            "check_name": "Agent Action Group IAM Least Privilege Check",
+            "status": "ERROR",
+            "details": f"Error during check: {str(e)}",
+            "csv_data": [
+                create_finding(
+                    check_id="BR-21",
+                    finding_name="Agent Action Group IAM Least Privilege Check",
+                    finding_details=f"Error during check: {str(e)}",
+                    resolution="Investigate error and retry assessment",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/agents-security.html",
+                    severity="High",
+                    status="Failed",
+                    region=region,
+                )
+            ],
+        }
+
+
+def check_bedrock_service_quotas_throttling(region: str = "") -> Dict[str, Any]:
+    """
+    BR-22: Verify service quotas are configured for model invocation throttling
+    """
+    logger.debug("Starting check for Bedrock service quotas throttling limits")
+    try:
+        findings = {
+            "check_name": "Model Invocation Throttling Limits Check",
+            "status": "PASS",
+            "details": "",
+            "csv_data": [],
+        }
+
+        service_quotas_client = boto3.client(
+            "service-quotas", config=boto3_config, region_name=region
+        )
+
+        try:
+            # List Bedrock service quotas
+            quotas_response = service_quotas_client.list_service_quotas(
+                ServiceCode="bedrock", MaxResults=100
+            )
+            quotas = quotas_response.get("Quotas", [])
+
+            if not quotas:
+                findings["details"] = "Could not retrieve Bedrock service quotas"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-22",
+                        finding_name="Model Invocation Throttling Limits Check",
+                        finding_details="Unable to retrieve Bedrock service quotas for this region",
+                        resolution="Verify service quotas access and ensure Bedrock is available in this region",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/quotas.html",
+                        severity="Medium",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+                return findings
+
+            # Check for custom quotas (non-default values indicate intentional configuration)
+            custom_quotas = []
+            default_quotas = []
+
+            for quota in quotas:
+                quota_name = quota.get("QuotaName", "unknown")
+                quota_code = quota.get("QuotaCode", "")
+
+                # Check if quota is related to throttling/rate limits
+                is_throttling_quota = any(
+                    keyword in quota_name.lower()
+                    for keyword in [
+                        "tokens per minute",
+                        "tpm",
+                        "requests per",
+                        "throughput",
+                        "invocations",
+                    ]
+                )
+
+                if is_throttling_quota:
+                    # Check if quota has been customized
+                    default_value = quota.get("Value", 0)
+                    adjustable = quota.get("Adjustable", False)
+
+                    # Try to get applied quota (custom value if set)
+                    try:
+                        applied_quota = service_quotas_client.get_service_quota(
+                            ServiceCode="bedrock", QuotaCode=quota_code
+                        )
+                        applied_value = applied_quota.get("Quota", {}).get(
+                            "Value", default_value
+                        )
+
+                        if applied_value != default_value or not adjustable:
+                            custom_quotas.append(
+                                {
+                                    "name": quota_name,
+                                    "value": applied_value,
+                                    "adjustable": adjustable,
+                                }
+                            )
+                        else:
+                            default_quotas.append(quota_name)
+                    except ClientError:
+                        # If we can't get applied quota, assume default
+                        if adjustable:
+                            default_quotas.append(quota_name)
+
+            if not custom_quotas and default_quotas:
+                findings["status"] = "WARN"
+                findings["details"] = "No custom throttling quotas configured"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-22",
+                        finding_name="Model Invocation Throttling Limits Check",
+                        finding_details="Account is using default Bedrock service quotas for model invocation throttling. Custom quotas help prevent abuse, control costs, and ensure fair resource usage across applications.",
+                        resolution="Review Bedrock service quotas and configure custom limits for model invocation rates (tokens per minute) based on your application requirements. Request quota increases through AWS Service Quotas console if needed. Set up CloudWatch alarms to monitor quota utilization.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/quotas.html",
+                        severity="Medium",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            elif custom_quotas:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-22",
+                        finding_name="Model Invocation Throttling Limits Check",
+                        finding_details=f"{len(custom_quotas)} custom throttling quotas are configured. Regular quota review helps maintain appropriate rate limits.",
+                        resolution="Continue monitoring quota utilization. Review and adjust quotas as application requirements change.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/quotas.html",
+                        severity="Low",
+                        status="Passed",
+                        region=region,
+                    )
+                )
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            error_msg = str(e)
+
+            if (
+                "NoSuchResourceException" in error_msg
+                or "not found" in error_msg.lower()
+            ):
+                findings["details"] = "Bedrock service quotas not available"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-22",
+                        finding_name="Model Invocation Throttling Limits Check",
+                        finding_details="Bedrock service quotas not found in Service Quotas API for this region",
+                        resolution="Bedrock may not be available in this region or quotas may not be published to Service Quotas API",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/quotas.html",
+                        severity="Low",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+            elif error_code in ACCESS_DENIED_ERROR_CODES:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-22",
+                        finding_name="Model Invocation Throttling Limits Check",
+                        finding_details=describe_api_error(
+                            e, "Service quotas check", region
+                        ),
+                        resolution="Grant servicequotas:ListServiceQuotas and servicequotas:GetServiceQuota permissions",
+                        reference="https://docs.aws.amazon.com/servicequotas/latest/userguide/identity-access-management.html",
+                        severity="Medium",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                raise
+
+        return findings
+
+    except Exception as e:
+        logger.error(
+            f"Error in check_bedrock_service_quotas_throttling: {str(e)}", exc_info=True
+        )
+        return {
+            "check_name": "Model Invocation Throttling Limits Check",
+            "status": "ERROR",
+            "details": f"Error during check: {str(e)}",
+            "csv_data": [
+                create_finding(
+                    check_id="BR-22",
+                    finding_name="Model Invocation Throttling Limits Check",
+                    finding_details=f"Error during check: {str(e)}",
+                    resolution="Investigate error and retry assessment",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/quotas.html",
+                    severity="Medium",
+                    status="Failed",
+                    region=region,
+                )
+            ],
+        }
+
+
+def check_bedrock_guardrail_content_filters(region: str = "") -> Dict[str, Any]:
+    """
+    BR-23: Verify guardrails have ALL content filters enabled (extends BR-05)
+    """
+    logger.debug("Starting check for Bedrock guardrail content filter coverage")
+    try:
+        findings = {
+            "check_name": "Guardrail Content Filter Coverage Check",
+            "status": "PASS",
+            "details": "",
+            "csv_data": [],
+        }
+
+        bedrock_client = boto3.client(
+            "bedrock", config=boto3_config, region_name=region
+        )
+
+        try:
+            # List all guardrails
+            guardrails_response = bedrock_client.list_guardrails(maxResults=100)
+            guardrails = guardrails_response.get("guardrails", [])
+
+            if not guardrails:
+                findings["details"] = "No Bedrock guardrails found"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-23",
+                        finding_name="Guardrail Content Filter Coverage Check",
+                        finding_details="No Bedrock guardrails configured in this region",
+                        resolution="Create guardrails with all content filters enabled (hate, insults, sexual, violence) with appropriate thresholds",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-content-filters.html",
+                        severity="High",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+                return findings
+
+            incomplete_guardrails = []
+            complete_guardrails = []
+
+            for guardrail_summary in guardrails:
+                guardrail_id = guardrail_summary.get("id")
+                guardrail_name = guardrail_summary.get("name", "unknown")
+
+                if not guardrail_id:
+                    continue
+
+                # Get detailed guardrail configuration
+                guardrail_detail = bedrock_client.get_guardrail(
+                    guardrailIdentifier=guardrail_id
+                )
+                guardrail_config = guardrail_detail.get("guardrail", guardrail_detail)
+
+                # Check content filter configuration. GetGuardrail reports the
+                # configured filters under contentPolicy.filters (the *Config
+                # field names are part of the Create/Update request shape, not the
+                # response).
+                content_policy = guardrail_config.get("contentPolicy", {})
+                filters_config = content_policy.get("filters", [])
+
+                # Required filter types
+                required_filters = {"HATE", "INSULTS", "SEXUAL", "VIOLENCE"}
+                configured_filters = set()
+                missing_filters = []
+
+                for filter_item in filters_config:
+                    filter_type = filter_item.get("type")
+                    input_strength = filter_item.get("inputStrength", "NONE")
+                    output_strength = filter_item.get("outputStrength", "NONE")
+
+                    if filter_type in required_filters:
+                        # Filter is considered configured if it has any strength other than NONE
+                        if input_strength != "NONE" or output_strength != "NONE":
+                            configured_filters.add(filter_type)
+
+                # Find missing filters
+                missing_filters = required_filters - configured_filters
+
+                if missing_filters:
+                    incomplete_guardrails.append(
+                        {
+                            "name": guardrail_name,
+                            "id": guardrail_id,
+                            "missing": list(missing_filters),
+                        }
+                    )
+                else:
+                    complete_guardrails.append(guardrail_name)
+
+            if incomplete_guardrails:
+                findings["status"] = "WARN"
+                findings["details"] = (
+                    f"Found {len(incomplete_guardrails)} guardrails with incomplete content filter coverage"
+                )
+
+                for gr in incomplete_guardrails:
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-23",
+                            finding_name="Guardrail Content Filter Coverage Check",
+                            finding_details=f"Guardrail '{gr['name']}' (ID: {gr['id']}) is missing content filters: {', '.join(gr['missing'])}. Complete content filter coverage is essential for comprehensive content safety.",
+                            resolution="Update guardrail to enable all content filters (HATE, INSULTS, SEXUAL, VIOLENCE). Configure appropriate threshold levels (LOW, MEDIUM, HIGH) for both input and output filtering based on your use case. Review AWS documentation for threshold guidance.",
+                            reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-content-filters.html",
+                            severity="High",
+                            status="Failed",
+                            region=region,
+                        )
+                    )
+
+            if complete_guardrails:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-23",
+                        finding_name="Guardrail Content Filter Coverage Check",
+                        finding_details=f"{len(complete_guardrails)} guardrails have complete content filter coverage (hate, insults, sexual, violence)",
+                        resolution="No action required. Continue monitoring filter effectiveness and adjust thresholds as needed.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-content-filters.html",
+                        severity="Low",
+                        status="Passed",
+                        region=region,
+                    )
+                )
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in ACCESS_DENIED_ERROR_CODES:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-23",
+                        finding_name="Guardrail Content Filter Coverage Check",
+                        finding_details=describe_api_error(
+                            e, "Guardrail content filter check", region
+                        ),
+                        resolution="Grant bedrock:ListGuardrails and bedrock:GetGuardrail permissions",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html",
+                        severity="High",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                raise
+
+        return findings
+
+    except Exception as e:
+        logger.error(
+            f"Error in check_bedrock_guardrail_content_filters: {str(e)}", exc_info=True
+        )
+        return {
+            "check_name": "Guardrail Content Filter Coverage Check",
+            "status": "ERROR",
+            "details": f"Error during check: {str(e)}",
+            "csv_data": [
+                create_finding(
+                    check_id="BR-23",
+                    finding_name="Guardrail Content Filter Coverage Check",
+                    finding_details=f"Error during check: {str(e)}",
+                    resolution="Investigate error and retry assessment",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-content-filters.html",
+                    severity="High",
+                    status="Failed",
+                    region=region,
+                )
+            ],
+        }
+
+
+def check_bedrock_automated_reasoning_policy(region: str = "") -> Dict[str, Any]:
+    """
+    BR-24: Check if Automated Reasoning policies are configured on guardrails
+    """
+    logger.debug("Starting check for Bedrock Automated Reasoning policy implementation")
+    try:
+        findings = {
+            "check_name": "Automated Reasoning Policy Implementation Check",
+            "status": "PASS",
+            "details": "",
+            "csv_data": [],
+        }
+
+        bedrock_client = boto3.client(
+            "bedrock", config=boto3_config, region_name=region
+        )
+
+        try:
+            # List all guardrails
+            guardrails_response = bedrock_client.list_guardrails(maxResults=100)
+            guardrails = guardrails_response.get("guardrails", [])
+
+            if not guardrails:
+                findings["details"] = "No Bedrock guardrails found"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-24",
+                        finding_name="Automated Reasoning Policy Implementation Check",
+                        finding_details="No Bedrock guardrails configured in this region",
+                        resolution="Create guardrails with Automated Reasoning policies for formal verification of model responses",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-automated-reasoning.html",
+                        severity="Medium",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+                return findings
+
+            without_ar_policy = []
+            with_ar_policy = []
+
+            for guardrail_summary in guardrails:
+                guardrail_id = guardrail_summary.get("id")
+                guardrail_name = guardrail_summary.get("name", "unknown")
+
+                if not guardrail_id:
+                    continue
+
+                # Get detailed guardrail configuration
+                try:
+                    guardrail_detail = bedrock_client.get_guardrail(
+                        guardrailIdentifier=guardrail_id
+                    )
+                    guardrail_config = guardrail_detail.get(
+                        "guardrail", guardrail_detail
+                    )
+
+                    # GetGuardrail reports Automated Reasoning under
+                    # automatedReasoningPolicy.policies. The guardrail has a policy
+                    # configured when that list is non-empty.
+                    ar_policy = guardrail_config.get("automatedReasoningPolicy") or {}
+                    has_ar_policy = bool(ar_policy.get("policies"))
+
+                    if not has_ar_policy:
+                        without_ar_policy.append(
+                            {"name": guardrail_name, "id": guardrail_id}
+                        )
+                    else:
+                        with_ar_policy.append(guardrail_name)
+
+                except ClientError as detail_error:
+                    error_code = detail_error.response.get("Error", {}).get("Code", "")
+                    if error_code not in ACCESS_DENIED_ERROR_CODES:
+                        logger.warning(
+                            f"Could not get details for guardrail {guardrail_name}: {error_code}"
+                        )
+
+            if without_ar_policy:
+                findings["status"] = "WARN"
+                findings["details"] = (
+                    f"Found {len(without_ar_policy)} guardrails without Automated Reasoning policies"
+                )
+
+                for gr in without_ar_policy:
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-24",
+                            finding_name="Automated Reasoning Policy Implementation Check",
+                            finding_details=f"Guardrail '{gr['name']}' (ID: {gr['id']}) does not have an Automated Reasoning policy configured. Automated Reasoning provides formal verification of model responses against defined policies.",
+                            resolution="Configure Automated Reasoning policies on guardrails to mathematically verify model responses. Define policies that specify allowed and disallowed behaviors. Use for high-assurance use cases where formal verification is required.",
+                            reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-automated-reasoning.html",
+                            severity="Medium",
+                            status="Failed",
+                            region=region,
+                        )
+                    )
+
+            if with_ar_policy:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-24",
+                        finding_name="Automated Reasoning Policy Implementation Check",
+                        finding_details=f"{len(with_ar_policy)} guardrails have Automated Reasoning policies configured for formal verification",
+                        resolution="No action required. Continue using Automated Reasoning for high-assurance verification.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-automated-reasoning.html",
+                        severity="Low",
+                        status="Passed",
+                        region=region,
+                    )
+                )
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            error_msg = str(e)
+
+            if "UnknownOperation" in error_msg or "Unknown operation" in error_msg:
+                findings["details"] = (
+                    "Automated Reasoning feature not available in this region"
+                )
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-24",
+                        finding_name="Automated Reasoning Policy Implementation Check",
+                        finding_details=describe_api_error(
+                            e, "Automated Reasoning API", region
+                        ),
+                        resolution="Automated Reasoning may not be available in all regions. Check AWS documentation for regional availability.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-automated-reasoning.html",
+                        severity="Low",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+            elif error_code in ACCESS_DENIED_ERROR_CODES:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-24",
+                        finding_name="Automated Reasoning Policy Implementation Check",
+                        finding_details=describe_api_error(
+                            e, "Automated Reasoning policy check", region
+                        ),
+                        resolution="Grant bedrock:ListGuardrails and bedrock:GetGuardrail permissions",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html",
+                        severity="Medium",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                raise
+
+        return findings
+
+    except Exception as e:
+        logger.error(
+            f"Error in check_bedrock_automated_reasoning_policy: {str(e)}",
+            exc_info=True,
+        )
+        return {
+            "check_name": "Automated Reasoning Policy Implementation Check",
+            "status": "ERROR",
+            "details": f"Error during check: {str(e)}",
+            "csv_data": [
+                create_finding(
+                    check_id="BR-24",
+                    finding_name="Automated Reasoning Policy Implementation Check",
+                    finding_details=f"Error during check: {str(e)}",
+                    resolution="Investigate error and retry assessment",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-automated-reasoning.html",
+                    severity="Medium",
+                    status="Failed",
+                    region=region,
+                )
+            ],
+        }
+
+
+def check_bedrock_rag_evaluation_jobs(region: str = "") -> Dict[str, Any]:
+    """
+    BR-25: Verify RAG applications have evaluation jobs configured
+    """
+    logger.debug("Starting check for Bedrock RAG evaluation jobs")
+    try:
+        findings = {
+            "check_name": "RAG Evaluation Jobs Check",
+            "status": "PASS",
+            "details": "",
+            "csv_data": [],
+        }
+
+        bedrock_agent_client = boto3.client(
+            "bedrock-agent", config=boto3_config, region_name=region
+        )
+        bedrock_client = boto3.client(
+            "bedrock", config=boto3_config, region_name=region
+        )
+
+        try:
+            # List all knowledge bases
+            kb_response = bedrock_agent_client.list_knowledge_bases(maxResults=100)
+            knowledge_bases = kb_response.get("knowledgeBaseSummaries", [])
+
+            if not knowledge_bases:
+                findings["details"] = "No knowledge bases found"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-25",
+                        finding_name="RAG Evaluation Jobs Check",
+                        finding_details="No Bedrock knowledge bases found in this region",
+                        resolution="When implementing RAG applications, configure evaluation jobs to assess context relevance, response correctness, and prevent hallucinations",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/model-evaluation-rag.html",
+                        severity="Low",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+                return findings
+
+            # List evaluation jobs (filter for RAG-related evaluations)
+            try:
+                eval_jobs_response = bedrock_client.list_evaluation_jobs(maxResults=100)
+                eval_jobs = eval_jobs_response.get("jobSummaries", [])
+
+                # Map knowledge bases to evaluation jobs
+                kbs_with_evals = set()
+                recent_evaluations = []
+                thirty_days_ago = datetime.now(timezone.utc) - timedelta(days=30)
+
+                for job in eval_jobs:
+                    job_name = job.get("jobName", "")
+                    job_status = job.get("status", "unknown")
+                    creation_time = job.get("creationTime")
+
+                    # Check if this is a RAG evaluation (simple heuristic: name contains kb id or "rag")
+                    is_rag_eval = "rag" in job_name.lower() or any(
+                        kb["knowledgeBaseId"] in job_name for kb in knowledge_bases
+                    )
+
+                    if is_rag_eval:
+                        # Check if evaluation is recent
+                        is_recent = False
+                        if creation_time:
+                            if isinstance(creation_time, str):
+                                try:
+                                    creation_time = datetime.fromisoformat(
+                                        creation_time.replace("Z", "+00:00")
+                                    )
+                                except ValueError:
+                                    pass
+                            if isinstance(creation_time, datetime):
+                                is_recent = creation_time >= thirty_days_ago
+
+                        if is_recent and job_status == "Completed":
+                            recent_evaluations.append(job_name)
+                            # Try to identify which KB this evaluation is for
+                            for kb in knowledge_bases:
+                                if kb["knowledgeBaseId"] in job_name:
+                                    kbs_with_evals.add(kb["knowledgeBaseId"])
+
+                kbs_without_evals = [
+                    kb
+                    for kb in knowledge_bases
+                    if kb["knowledgeBaseId"] not in kbs_with_evals
+                ]
+
+                if kbs_without_evals:
+                    findings["status"] = "WARN"
+                    findings["details"] = (
+                        f"Found {len(kbs_without_evals)} knowledge bases without recent RAG evaluation jobs"
+                    )
+
+                    for kb in kbs_without_evals:
+                        findings["csv_data"].append(
+                            create_finding(
+                                check_id="BR-25",
+                                finding_name="RAG Evaluation Jobs Check",
+                                finding_details=f"Knowledge base '{kb['name']}' (ID: {kb['knowledgeBaseId']}) does not have recent RAG evaluation jobs. RAG evaluations assess context relevance, response correctness, faithfulness, and harmfulness to prevent hallucinations.",
+                                resolution="Create RAG evaluation jobs for knowledge bases using Amazon Bedrock Model Evaluation. Configure evaluations to test context relevance, answer correctness, and faithfulness metrics. Run evaluations regularly (monthly or after significant KB updates) to maintain quality.",
+                                reference="https://docs.aws.amazon.com/bedrock/latest/userguide/model-evaluation-rag.html",
+                                severity="Low",
+                                status="Failed",
+                                region=region,
+                            )
+                        )
+
+                if recent_evaluations:
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-25",
+                            finding_name="RAG Evaluation Jobs Check",
+                            finding_details=f"Found {len(recent_evaluations)} recent RAG evaluation jobs. Regular RAG evaluations help maintain response quality and prevent hallucinations.",
+                            resolution="Continue regular RAG evaluations. Review evaluation results and adjust retrieval strategies or knowledge base content as needed.",
+                            reference="https://docs.aws.amazon.com/bedrock/latest/userguide/model-evaluation-rag.html",
+                            severity="Low",
+                            status="Passed",
+                            region=region,
+                        )
+                    )
+
+            except ClientError as eval_error:
+                error_code = eval_error.response.get("Error", {}).get("Code", "")
+                if error_code not in ACCESS_DENIED_ERROR_CODES:
+                    logger.warning(f"Could not list evaluation jobs: {error_code}")
+                    # Continue check even if evaluation jobs API fails
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in ACCESS_DENIED_ERROR_CODES:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-25",
+                        finding_name="RAG Evaluation Jobs Check",
+                        finding_details=describe_api_error(
+                            e, "RAG evaluation check", region
+                        ),
+                        resolution="Grant bedrock-agent:ListKnowledgeBases and bedrock:ListEvaluationJobs permissions",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html",
+                        severity="Low",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                raise
+
+        return findings
+
+    except Exception as e:
+        logger.error(
+            f"Error in check_bedrock_rag_evaluation_jobs: {str(e)}", exc_info=True
+        )
+        return {
+            "check_name": "RAG Evaluation Jobs Check",
+            "status": "ERROR",
+            "details": f"Error during check: {str(e)}",
+            "csv_data": [
+                create_finding(
+                    check_id="BR-25",
+                    finding_name="RAG Evaluation Jobs Check",
+                    finding_details=f"Error during check: {str(e)}",
+                    resolution="Investigate error and retry assessment",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/model-evaluation-rag.html",
+                    severity="Low",
+                    status="Failed",
+                    region=region,
+                )
+            ],
+        }
+
+
+def check_bedrock_guardrail_pii_filters(region: str = "") -> Dict[str, Any]:
+    """
+    BR-26: Verify guardrails configure sensitive-information (PII) protection
+    (extends BR-23, which only covers the harmful-content filters).
+    """
+    logger.debug("Starting check for Bedrock guardrail sensitive-information filters")
+    try:
+        findings = {
+            "check_name": "Guardrail Sensitive Information Filter Check",
+            "status": "PASS",
+            "details": "",
+            "csv_data": [],
+        }
+
+        bedrock_client = boto3.client(
+            "bedrock", config=boto3_config, region_name=region
+        )
+
+        try:
+            guardrails_response = bedrock_client.list_guardrails(maxResults=100)
+            guardrails = guardrails_response.get("guardrails", [])
+
+            if not guardrails:
+                findings["details"] = "No Bedrock guardrails found"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-26",
+                        finding_name="Guardrail Sensitive Information Filter Check",
+                        finding_details="No Bedrock guardrails configured in this region",
+                        resolution="Create guardrails with sensitive-information filters (PII entities and/or regex patterns) to detect and redact sensitive data in prompts and model responses",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-sensitive-filters.html",
+                        severity="High",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+                return findings
+
+            guardrails_without_pii = []
+            guardrails_with_pii = []
+
+            for guardrail_summary in guardrails:
+                guardrail_id = guardrail_summary.get("id")
+                guardrail_name = guardrail_summary.get("name", "unknown")
+
+                if not guardrail_id:
+                    continue
+
+                guardrail_detail = bedrock_client.get_guardrail(
+                    guardrailIdentifier=guardrail_id
+                )
+                guardrail_config = guardrail_detail.get("guardrail", guardrail_detail)
+
+                # GetGuardrail reports PII protection under
+                # sensitiveInformationPolicy.piiEntities and .regexes.
+                sensitive_policy = guardrail_config.get(
+                    "sensitiveInformationPolicy", {}
+                )
+                pii_entities = sensitive_policy.get("piiEntities", [])
+                regexes = sensitive_policy.get("regexes", [])
+
+                if pii_entities or regexes:
+                    guardrails_with_pii.append(guardrail_name)
+                else:
+                    guardrails_without_pii.append(
+                        {"name": guardrail_name, "id": guardrail_id}
+                    )
+
+            if guardrails_without_pii:
+                findings["status"] = "WARN"
+                findings["details"] = (
+                    f"Found {len(guardrails_without_pii)} guardrails without sensitive-information filters"
+                )
+
+                for gr in guardrails_without_pii:
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-26",
+                            finding_name="Guardrail Sensitive Information Filter Check",
+                            finding_details=f"Guardrail '{gr['name']}' (ID: {gr['id']}) has no sensitive-information filters configured (no PII entities or regex patterns). Prompts and model responses are not screened for sensitive data such as PII.",
+                            resolution="Configure sensitive-information filters on the guardrail: add PII entity types (e.g. NAME, EMAIL, SSN, CREDIT_DEBIT_CARD_NUMBER) and/or custom regex patterns, and set the appropriate BLOCK or ANONYMIZE action for input and output.",
+                            reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-sensitive-filters.html",
+                            severity="High",
+                            status="Failed",
+                            region=region,
+                        )
+                    )
+
+            if guardrails_with_pii:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-26",
+                        finding_name="Guardrail Sensitive Information Filter Check",
+                        finding_details=f"{len(guardrails_with_pii)} guardrails have sensitive-information (PII) filters configured",
+                        resolution="No action required. Periodically review the PII entity types and regex patterns to ensure coverage matches your data.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-sensitive-filters.html",
+                        severity="Low",
+                        status="Passed",
+                        region=region,
+                    )
+                )
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in ACCESS_DENIED_ERROR_CODES:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-26",
+                        finding_name="Guardrail Sensitive Information Filter Check",
+                        finding_details=describe_api_error(
+                            e, "Guardrail sensitive information check", region
+                        ),
+                        resolution="Grant bedrock:ListGuardrails and bedrock:GetGuardrail permissions",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html",
+                        severity="High",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                raise
+
+        return findings
+
+    except Exception as e:
+        logger.error(
+            f"Error in check_bedrock_guardrail_pii_filters: {str(e)}", exc_info=True
+        )
+        return {
+            "check_name": "Guardrail Sensitive Information Filter Check",
+            "status": "ERROR",
+            "details": f"Error during check: {str(e)}",
+            "csv_data": [
+                create_finding(
+                    check_id="BR-26",
+                    finding_name="Guardrail Sensitive Information Filter Check",
+                    finding_details=f"Error during check: {str(e)}",
+                    resolution="Investigate error and retry assessment",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-sensitive-filters.html",
+                    severity="High",
+                    status="Failed",
+                    region=region,
+                )
+            ],
+        }
+
+
+def check_bedrock_guardrail_contextual_grounding(region: str = "") -> Dict[str, Any]:
+    """
+    BR-27: Verify guardrails enable contextual grounding checks to detect
+    hallucinations and irrelevant responses (extends BR-05).
+    """
+    logger.debug("Starting check for Bedrock guardrail contextual grounding")
+    try:
+        findings = {
+            "check_name": "Guardrail Contextual Grounding Check",
+            "status": "PASS",
+            "details": "",
+            "csv_data": [],
+        }
+
+        bedrock_client = boto3.client(
+            "bedrock", config=boto3_config, region_name=region
+        )
+
+        try:
+            guardrails_response = bedrock_client.list_guardrails(maxResults=100)
+            guardrails = guardrails_response.get("guardrails", [])
+
+            if not guardrails:
+                findings["details"] = "No Bedrock guardrails found"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-27",
+                        finding_name="Guardrail Contextual Grounding Check",
+                        finding_details="No Bedrock guardrails configured in this region",
+                        resolution="Create guardrails with contextual grounding checks to detect hallucinations (ungrounded responses) and irrelevant answers, especially for RAG applications",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-contextual-grounding-check.html",
+                        severity="Medium",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+                return findings
+
+            guardrails_without_grounding = []
+            guardrails_with_grounding = []
+
+            for guardrail_summary in guardrails:
+                guardrail_id = guardrail_summary.get("id")
+                guardrail_name = guardrail_summary.get("name", "unknown")
+
+                if not guardrail_id:
+                    continue
+
+                guardrail_detail = bedrock_client.get_guardrail(
+                    guardrailIdentifier=guardrail_id
+                )
+                guardrail_config = guardrail_detail.get("guardrail", guardrail_detail)
+
+                # GetGuardrail reports grounding/relevance checks under
+                # contextualGroundingPolicy.filters. A filter is active when it
+                # is enabled (the enabled flag defaults to True when omitted).
+                grounding_policy = guardrail_config.get("contextualGroundingPolicy", {})
+                grounding_filters = grounding_policy.get("filters", [])
+                active_filters = [
+                    f for f in grounding_filters if f.get("enabled", True)
+                ]
+
+                if active_filters:
+                    guardrails_with_grounding.append(guardrail_name)
+                else:
+                    guardrails_without_grounding.append(
+                        {"name": guardrail_name, "id": guardrail_id}
+                    )
+
+            if guardrails_without_grounding:
+                findings["status"] = "WARN"
+                findings["details"] = (
+                    f"Found {len(guardrails_without_grounding)} guardrails without contextual grounding checks"
+                )
+
+                for gr in guardrails_without_grounding:
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-27",
+                            finding_name="Guardrail Contextual Grounding Check",
+                            finding_details=f"Guardrail '{gr['name']}' (ID: {gr['id']}) does not have contextual grounding checks enabled. Without grounding and relevance checks, the guardrail cannot detect hallucinated (ungrounded) or off-topic model responses.",
+                            resolution="Enable contextual grounding checks (GROUNDING and RELEVANCE filter types) on the guardrail with appropriate thresholds. This is especially important for RAG applications to ensure responses are grounded in the retrieved source material.",
+                            reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-contextual-grounding-check.html",
+                            severity="Medium",
+                            status="Failed",
+                            region=region,
+                        )
+                    )
+
+            if guardrails_with_grounding:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-27",
+                        finding_name="Guardrail Contextual Grounding Check",
+                        finding_details=f"{len(guardrails_with_grounding)} guardrails have contextual grounding checks enabled",
+                        resolution="No action required. Review grounding and relevance thresholds periodically to balance hallucination detection against false positives.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-contextual-grounding-check.html",
+                        severity="Low",
+                        status="Passed",
+                        region=region,
+                    )
+                )
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in ACCESS_DENIED_ERROR_CODES:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-27",
+                        finding_name="Guardrail Contextual Grounding Check",
+                        finding_details=describe_api_error(
+                            e, "Guardrail contextual grounding check", region
+                        ),
+                        resolution="Grant bedrock:ListGuardrails and bedrock:GetGuardrail permissions",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html",
+                        severity="Medium",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                raise
+
+        return findings
+
+    except Exception as e:
+        logger.error(
+            f"Error in check_bedrock_guardrail_contextual_grounding: {str(e)}",
+            exc_info=True,
+        )
+        return {
+            "check_name": "Guardrail Contextual Grounding Check",
+            "status": "ERROR",
+            "details": f"Error during check: {str(e)}",
+            "csv_data": [
+                create_finding(
+                    check_id="BR-27",
+                    finding_name="Guardrail Contextual Grounding Check",
+                    finding_details=f"Error during check: {str(e)}",
+                    resolution="Investigate error and retry assessment",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-contextual-grounding-check.html",
+                    severity="Medium",
+                    status="Failed",
+                    region=region,
+                )
+            ],
+        }
+
+
+def check_bedrock_agent_guardrail_association(region: str = "") -> Dict[str, Any]:
+    """
+    BR-28: Verify each Bedrock Agent has a guardrail associated so that agent
+    interactions are subject to safety controls.
+    """
+    logger.debug("Starting check for Bedrock Agent guardrail association")
+    try:
+        findings = {
+            "check_name": "Agent Guardrail Association Check",
+            "status": "PASS",
+            "details": "",
+            "csv_data": [],
+        }
+
+        bedrock_agent_client = boto3.client(
+            "bedrock-agent", config=boto3_config, region_name=region
+        )
+
+        try:
+            # list_agents summaries already include guardrailConfiguration, so no
+            # per-agent get_agent call is required.
+            agents = []
+            paginator = bedrock_agent_client.get_paginator("list_agents")
+            for page in paginator.paginate():
+                agents.extend(page.get("agentSummaries", []))
+
+            if not agents:
+                findings["details"] = "No Bedrock agents found"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-28",
+                        finding_name="Agent Guardrail Association Check",
+                        finding_details="No Bedrock agents configured in this region",
+                        resolution="When creating agents, associate a Bedrock guardrail so agent inputs and responses are filtered for harmful content, PII, and denied topics",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/agents-guardrails.html",
+                        severity="High",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+                return findings
+
+            agents_without_guardrail = []
+            agents_with_guardrail = []
+
+            for agent in agents:
+                agent_id = agent.get("agentId")
+                agent_name = agent.get("agentName", agent_id or "unknown")
+
+                guardrail_config = agent.get("guardrailConfiguration") or {}
+                if guardrail_config.get("guardrailIdentifier"):
+                    agents_with_guardrail.append(agent_name)
+                else:
+                    agents_without_guardrail.append(
+                        {"name": agent_name, "id": agent_id}
+                    )
+
+            if agents_without_guardrail:
+                findings["status"] = "WARN"
+                findings["details"] = (
+                    f"Found {len(agents_without_guardrail)} agents without an associated guardrail"
+                )
+
+                for agent in agents_without_guardrail:
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-28",
+                            finding_name="Agent Guardrail Association Check",
+                            finding_details=f"Bedrock agent '{agent['name']}' (ID: {agent['id']}) does not have a guardrail associated. Agent interactions are not subject to content filtering, PII protection, or denied-topic controls.",
+                            resolution="Associate a Bedrock guardrail with the agent by setting guardrailConfiguration (guardrailIdentifier and guardrailVersion) on the agent. Prepare the agent after updating so the change takes effect.",
+                            reference="https://docs.aws.amazon.com/bedrock/latest/userguide/agents-guardrails.html",
+                            severity="High",
+                            status="Failed",
+                            region=region,
+                        )
+                    )
+
+            if agents_with_guardrail:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-28",
+                        finding_name="Agent Guardrail Association Check",
+                        finding_details=f"{len(agents_with_guardrail)} agents have an associated guardrail",
+                        resolution="No action required. Continue associating guardrails with new agents.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/agents-guardrails.html",
+                        severity="Low",
+                        status="Passed",
+                        region=region,
+                    )
+                )
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            error_msg = str(e)
+            if "UnknownOperation" in error_msg or "Unknown operation" in error_msg:
+                findings["details"] = "Bedrock Agents API not available in this region"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-28",
+                        finding_name="Agent Guardrail Association Check",
+                        finding_details=describe_api_error(
+                            e, "Bedrock Agents API", region
+                        ),
+                        resolution="Bedrock Agents may not be available in all regions",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/agents-guardrails.html",
+                        severity="Low",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+            elif error_code in ACCESS_DENIED_ERROR_CODES:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-28",
+                        finding_name="Agent Guardrail Association Check",
+                        finding_details=describe_api_error(
+                            e, "Agent guardrail association check", region
+                        ),
+                        resolution="Grant bedrock-agent:ListAgents permission",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html",
+                        severity="High",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                raise
+
+        return findings
+
+    except Exception as e:
+        logger.error(
+            f"Error in check_bedrock_agent_guardrail_association: {str(e)}",
+            exc_info=True,
+        )
+        return {
+            "check_name": "Agent Guardrail Association Check",
+            "status": "ERROR",
+            "details": f"Error during check: {str(e)}",
+            "csv_data": [
+                create_finding(
+                    check_id="BR-28",
+                    finding_name="Agent Guardrail Association Check",
+                    finding_details=f"Error during check: {str(e)}",
+                    resolution="Investigate error and retry assessment",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/agents-guardrails.html",
+                    severity="High",
+                    status="Failed",
+                    region=region,
+                )
+            ],
+        }
+
+
+# Agents with an idle session TTL longer than this (in seconds) are flagged.
+# Default Bedrock value is 600s (10 min); 3600s (1 hour) is a generous ceiling.
+AGENT_MAX_IDLE_SESSION_TTL_SECONDS = 3600
+
+
+def check_bedrock_agent_idle_session_ttl(region: str = "") -> Dict[str, Any]:
+    """
+    BR-29: Verify Bedrock Agents do not use an excessively long idle session TTL,
+    which widens the window for session/context reuse abuse.
+    """
+    logger.debug("Starting check for Bedrock Agent idle session TTL")
+    try:
+        findings = {
+            "check_name": "Agent Idle Session TTL Check",
+            "status": "PASS",
+            "details": "",
+            "csv_data": [],
+        }
+
+        bedrock_agent_client = boto3.client(
+            "bedrock-agent", config=boto3_config, region_name=region
+        )
+
+        try:
+            agents = []
+            paginator = bedrock_agent_client.get_paginator("list_agents")
+            for page in paginator.paginate():
+                agents.extend(page.get("agentSummaries", []))
+
+            if not agents:
+                findings["details"] = "No Bedrock agents found"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-29",
+                        finding_name="Agent Idle Session TTL Check",
+                        finding_details="No Bedrock agents configured in this region",
+                        resolution="When creating agents, set a conservative idleSessionTTLInSeconds to limit how long an idle session remains resumable",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/agents-create.html",
+                        severity="Low",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+                return findings
+
+            agents_long_ttl = []
+            agents_ok_ttl = []
+
+            for agent in agents:
+                agent_id = agent.get("agentId")
+                agent_name = agent.get("agentName", agent_id or "unknown")
+
+                if not agent_id:
+                    continue
+
+                # idleSessionTTLInSeconds is only returned by GetAgent, not in the
+                # list summary.
+                try:
+                    agent_detail = bedrock_agent_client.get_agent(agentId=agent_id)
+                    agent_config = agent_detail.get("agent", agent_detail)
+                    ttl = agent_config.get("idleSessionTTLInSeconds")
+
+                    if ttl is None:
+                        continue
+
+                    if ttl > AGENT_MAX_IDLE_SESSION_TTL_SECONDS:
+                        agents_long_ttl.append(
+                            {"name": agent_name, "id": agent_id, "ttl": ttl}
+                        )
+                    else:
+                        agents_ok_ttl.append(agent_name)
+
+                except ClientError as detail_error:
+                    error_code = detail_error.response.get("Error", {}).get("Code", "")
+                    if error_code not in ACCESS_DENIED_ERROR_CODES:
+                        logger.warning(
+                            f"Could not get details for agent {agent_name}: {error_code}"
+                        )
+
+            if agents_long_ttl:
+                findings["status"] = "WARN"
+                findings["details"] = (
+                    f"Found {len(agents_long_ttl)} agents with an idle session TTL above {AGENT_MAX_IDLE_SESSION_TTL_SECONDS} seconds"
+                )
+
+                for agent in agents_long_ttl:
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-29",
+                            finding_name="Agent Idle Session TTL Check",
+                            finding_details=f"Bedrock agent '{agent['name']}' (ID: {agent['id']}) has an idle session TTL of {agent['ttl']} seconds, which exceeds the recommended maximum of {AGENT_MAX_IDLE_SESSION_TTL_SECONDS} seconds. Long-lived idle sessions widen the window for session and conversation-context reuse.",
+                            resolution=f"Reduce idleSessionTTLInSeconds to {AGENT_MAX_IDLE_SESSION_TTL_SECONDS} seconds or less, based on your application's session requirements, so idle sessions expire promptly.",
+                            reference="https://docs.aws.amazon.com/bedrock/latest/userguide/agents-create.html",
+                            severity="Low",
+                            status="Failed",
+                            region=region,
+                        )
+                    )
+
+            if agents_ok_ttl:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-29",
+                        finding_name="Agent Idle Session TTL Check",
+                        finding_details=f"{len(agents_ok_ttl)} agents use an idle session TTL within the recommended bound",
+                        resolution="No action required.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/agents-create.html",
+                        severity="Low",
+                        status="Passed",
+                        region=region,
+                    )
+                )
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            error_msg = str(e)
+            if "UnknownOperation" in error_msg or "Unknown operation" in error_msg:
+                findings["details"] = "Bedrock Agents API not available in this region"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-29",
+                        finding_name="Agent Idle Session TTL Check",
+                        finding_details=describe_api_error(
+                            e, "Bedrock Agents API", region
+                        ),
+                        resolution="Bedrock Agents may not be available in all regions",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/agents-create.html",
+                        severity="Low",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+            elif error_code in ACCESS_DENIED_ERROR_CODES:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-29",
+                        finding_name="Agent Idle Session TTL Check",
+                        finding_details=describe_api_error(
+                            e, "Agent idle session TTL check", region
+                        ),
+                        resolution="Grant bedrock-agent:ListAgents and bedrock-agent:GetAgent permissions",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html",
+                        severity="Low",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                raise
+
+        return findings
+
+    except Exception as e:
+        logger.error(
+            f"Error in check_bedrock_agent_idle_session_ttl: {str(e)}", exc_info=True
+        )
+        return {
+            "check_name": "Agent Idle Session TTL Check",
+            "status": "ERROR",
+            "details": f"Error during check: {str(e)}",
+            "csv_data": [
+                create_finding(
+                    check_id="BR-29",
+                    finding_name="Agent Idle Session TTL Check",
+                    finding_details=f"Error during check: {str(e)}",
+                    resolution="Investigate error and retry assessment",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/agents-create.html",
+                    severity="Low",
+                    status="Failed",
+                    region=region,
+                )
+            ],
+        }
+
+
+def check_bedrock_imported_model_kms_encryption(region: str = "") -> Dict[str, Any]:
+    """
+    BR-30: Verify imported custom models use customer-managed KMS keys
+    (complements BR-11/BR-17, which cover fine-tuned custom models).
+    """
+    logger.debug("Starting check for imported model KMS encryption")
+    try:
+        findings = {
+            "check_name": "Imported Model Customer-Managed KMS Encryption Check",
+            "status": "PASS",
+            "details": "",
+            "csv_data": [],
+        }
+
+        bedrock_client = boto3.client(
+            "bedrock", config=boto3_config, region_name=region
+        )
+
+        try:
+            imported_models = []
+            paginator = bedrock_client.get_paginator("list_imported_models")
+            for page in paginator.paginate():
+                imported_models.extend(page.get("modelSummaries", []))
+
+            if not imported_models:
+                findings["details"] = "No imported models found"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-30",
+                        finding_name="Imported Model Customer-Managed KMS Encryption Check",
+                        finding_details="No imported custom Bedrock models found in this region",
+                        resolution="When importing models, specify a customer-managed KMS key for encryption to maintain control over encryption keys",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html",
+                        severity="High",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+                return findings
+
+            models_with_aws_keys = []
+            models_with_customer_keys = []
+
+            for model in imported_models:
+                model_arn = model.get("modelArn")
+                model_name = model.get("modelName", "unknown")
+
+                try:
+                    model_detail = bedrock_client.get_imported_model(
+                        modelIdentifier=model_arn
+                    )
+                    # GetImportedModel reports the encryption key as modelKmsKeyArn.
+                    kms_key_arn = model_detail.get("modelKmsKeyArn")
+
+                    if kms_key_arn and kms_key_arn.startswith("arn:aws:kms"):
+                        models_with_customer_keys.append(model_name)
+                    else:
+                        models_with_aws_keys.append(
+                            {"name": model_name, "arn": model_arn}
+                        )
+
+                except ClientError as detail_error:
+                    error_code = detail_error.response.get("Error", {}).get("Code", "")
+                    if error_code not in ACCESS_DENIED_ERROR_CODES:
+                        logger.warning(
+                            f"Could not get details for imported model {model_name}: {error_code}"
+                        )
+
+            if models_with_aws_keys:
+                findings["status"] = "WARN"
+                findings["details"] = (
+                    f"Found {len(models_with_aws_keys)} imported models without a customer-managed KMS key"
+                )
+
+                for model_info in models_with_aws_keys:
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-30",
+                            finding_name="Imported Model Customer-Managed KMS Encryption Check",
+                            finding_details=f"Imported model '{model_info['name']}' is not encrypted with a customer-managed KMS key. This limits your control over key rotation, access policies, and audit trail.",
+                            resolution="Re-import the model specifying a customer-managed KMS key (modelKmsKeyArn). Ensure the KMS key policy grants Amazon Bedrock service access.",
+                            reference="https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html",
+                            severity="High",
+                            status="Failed",
+                            region=region,
+                        )
+                    )
+
+            if models_with_customer_keys:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-30",
+                        finding_name="Imported Model Customer-Managed KMS Encryption Check",
+                        finding_details=f"{len(models_with_customer_keys)} imported models are using customer-managed KMS keys for encryption",
+                        resolution="No action required. Continue using customer-managed keys for imported models.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html",
+                        severity="Medium",
+                        status="Passed",
+                        region=region,
+                    )
+                )
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            error_msg = str(e)
+            if "UnknownOperation" in error_msg or "Unknown operation" in error_msg:
+                findings["details"] = "Imported models API not available in this region"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-30",
+                        finding_name="Imported Model Customer-Managed KMS Encryption Check",
+                        finding_details=describe_api_error(
+                            e, "Imported models API", region
+                        ),
+                        resolution="Model import may not be available in all regions",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html",
+                        severity="Low",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+            elif error_code in ACCESS_DENIED_ERROR_CODES:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-30",
+                        finding_name="Imported Model Customer-Managed KMS Encryption Check",
+                        finding_details=describe_api_error(
+                            e, "Imported model encryption check", region
+                        ),
+                        resolution="Grant bedrock:ListImportedModels and bedrock:GetImportedModel permissions",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html",
+                        severity="High",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                raise
+
+        return findings
+
+    except Exception as e:
+        logger.error(
+            f"Error in check_bedrock_imported_model_kms_encryption: {str(e)}",
+            exc_info=True,
+        )
+        return {
+            "check_name": "Imported Model Customer-Managed KMS Encryption Check",
+            "status": "ERROR",
+            "details": f"Error during check: {str(e)}",
+            "csv_data": [
+                create_finding(
+                    check_id="BR-30",
+                    finding_name="Imported Model Customer-Managed KMS Encryption Check",
+                    finding_details=f"Error during check: {str(e)}",
+                    resolution="Investigate error and retry assessment",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-import-model.html",
+                    severity="High",
+                    status="Failed",
+                    region=region,
+                )
+            ],
+        }
+
+
+def check_bedrock_batch_inference_output_encryption(
+    region: str = "",
+) -> Dict[str, Any]:
+    """
+    BR-31: Verify batch inference (model invocation) jobs encrypt their S3 output
+    with a customer-managed KMS key.
+    """
+    logger.debug("Starting check for batch inference output encryption")
+    try:
+        findings = {
+            "check_name": "Batch Inference Output Encryption Check",
+            "status": "PASS",
+            "details": "",
+            "csv_data": [],
+        }
+
+        bedrock_client = boto3.client(
+            "bedrock", config=boto3_config, region_name=region
+        )
+
+        try:
+            # list_model_invocation_jobs summaries already include
+            # outputDataConfig.s3OutputDataConfig.s3EncryptionKeyId, so no
+            # per-job get_model_invocation_job call is required.
+            jobs = []
+            paginator = bedrock_client.get_paginator("list_model_invocation_jobs")
+            for page in paginator.paginate():
+                jobs.extend(page.get("invocationJobSummaries", []))
+
+            if not jobs:
+                findings["details"] = "No batch inference jobs found"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-31",
+                        finding_name="Batch Inference Output Encryption Check",
+                        finding_details="No Bedrock batch inference (model invocation) jobs found in this region",
+                        resolution="When creating batch inference jobs, set outputDataConfig.s3OutputDataConfig.s3EncryptionKeyId to a customer-managed KMS key to encrypt the job output",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference.html",
+                        severity="Medium",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+                return findings
+
+            jobs_without_cmk = []
+            jobs_with_cmk = []
+
+            for job in jobs:
+                job_name = job.get("jobName", "unknown")
+                output_config = job.get("outputDataConfig", {})
+                s3_output = output_config.get("s3OutputDataConfig", {})
+                encryption_key = s3_output.get("s3EncryptionKeyId")
+
+                if encryption_key:
+                    jobs_with_cmk.append(job_name)
+                else:
+                    jobs_without_cmk.append(job_name)
+
+            if jobs_without_cmk:
+                findings["status"] = "WARN"
+                findings["details"] = (
+                    f"Found {len(jobs_without_cmk)} batch inference jobs without a customer-managed KMS output key"
+                )
+
+                for job_name in jobs_without_cmk:
+                    findings["csv_data"].append(
+                        create_finding(
+                            check_id="BR-31",
+                            finding_name="Batch Inference Output Encryption Check",
+                            finding_details=f"Batch inference job '{job_name}' does not specify a customer-managed KMS key for its S3 output. Job output (model responses) may be encrypted only with the bucket default or an AWS-managed key.",
+                            resolution="When creating batch inference jobs, set outputDataConfig.s3OutputDataConfig.s3EncryptionKeyId to a customer-managed KMS key, and ensure the destination S3 bucket enforces that key.",
+                            reference="https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference.html",
+                            severity="Medium",
+                            status="Failed",
+                            region=region,
+                        )
+                    )
+
+            if jobs_with_cmk:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-31",
+                        finding_name="Batch Inference Output Encryption Check",
+                        finding_details=f"{len(jobs_with_cmk)} batch inference jobs specify a customer-managed KMS key for their S3 output",
+                        resolution="No action required. Continue specifying a customer-managed KMS key for batch inference output.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference.html",
+                        severity="Low",
+                        status="Passed",
+                        region=region,
+                    )
+                )
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            error_msg = str(e)
+            if "UnknownOperation" in error_msg or "Unknown operation" in error_msg:
+                findings["details"] = "Batch inference API not available in this region"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-31",
+                        finding_name="Batch Inference Output Encryption Check",
+                        finding_details=describe_api_error(
+                            e, "Batch inference API", region
+                        ),
+                        resolution="Batch inference may not be available in all regions",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference.html",
+                        severity="Low",
+                        status="N/A",
+                        region=region,
+                    )
+                )
+            elif error_code in ACCESS_DENIED_ERROR_CODES:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-31",
+                        finding_name="Batch Inference Output Encryption Check",
+                        finding_details=describe_api_error(
+                            e, "Batch inference output encryption check", region
+                        ),
+                        resolution="Grant bedrock:ListModelInvocationJobs permission",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html",
+                        severity="Medium",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                raise
+
+        return findings
+
+    except Exception as e:
+        logger.error(
+            f"Error in check_bedrock_batch_inference_output_encryption: {str(e)}",
+            exc_info=True,
+        )
+        return {
+            "check_name": "Batch Inference Output Encryption Check",
+            "status": "ERROR",
+            "details": f"Error during check: {str(e)}",
+            "csv_data": [
+                create_finding(
+                    check_id="BR-31",
+                    finding_name="Batch Inference Output Encryption Check",
+                    finding_details=f"Error during check: {str(e)}",
+                    resolution="Investigate error and retry assessment",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/batch-inference.html",
+                    severity="Medium",
+                    status="Failed",
+                    region=region,
+                )
+            ],
+        }
+
+
+def check_bedrock_cloudwatch_alarms(region: str = "") -> Dict[str, Any]:
+    """
+    BR-32: Verify CloudWatch alarms exist on Amazon Bedrock runtime metrics
+    (AWS/Bedrock namespace) to detect abuse, throttling, and cost spikes.
+    """
+    logger.debug("Starting check for CloudWatch alarms on Bedrock metrics")
+    try:
+        findings = {
+            "check_name": "Bedrock CloudWatch Alarm Check",
+            "status": "PASS",
+            "details": "",
+            "csv_data": [],
+        }
+
+        # Only assess this when the region actually has Bedrock resources, to
+        # avoid recommending alarms in regions where Bedrock is unused.
+        bedrock_footprint_found = detect_bedrock_regional_footprint(region=region)
+        if bedrock_footprint_found is False:
+            findings["details"] = "No regional Bedrock resources found"
+            findings["csv_data"].append(
+                create_finding(
+                    check_id="BR-32",
+                    finding_name="Bedrock CloudWatch Alarm Check",
+                    finding_details="No regional Bedrock resources found to monitor with CloudWatch alarms",
+                    resolution="No action required",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/monitoring-runtime-metrics.html",
+                    severity="Informational",
+                    status="N/A",
+                    region=region,
+                )
+            )
+            return findings
+
+        cloudwatch_client = boto3.client(
+            "cloudwatch", config=boto3_config, region_name=region
+        )
+
+        try:
+            bedrock_alarms = []
+            paginator = cloudwatch_client.get_paginator("describe_alarms")
+            for page in paginator.paginate(AlarmTypes=["MetricAlarm"]):
+                for alarm in page.get("MetricAlarms", []):
+                    # A metric alarm targets Bedrock either directly (Namespace)
+                    # or via a metric-math expression referencing AWS/Bedrock.
+                    if alarm.get("Namespace") == "AWS/Bedrock":
+                        bedrock_alarms.append(alarm.get("AlarmName"))
+                        continue
+                    for metric in alarm.get("Metrics", []):
+                        metric_stat = metric.get("MetricStat", {})
+                        namespace = metric_stat.get("Metric", {}).get("Namespace", "")
+                        if namespace == "AWS/Bedrock":
+                            bedrock_alarms.append(alarm.get("AlarmName"))
+                            break
+
+            if bedrock_alarms:
+                findings["details"] = (
+                    f"Found {len(bedrock_alarms)} CloudWatch alarms on Bedrock metrics"
+                )
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-32",
+                        finding_name="Bedrock CloudWatch Alarm Check",
+                        finding_details=f"Found {len(bedrock_alarms)} CloudWatch alarm(s) monitoring Amazon Bedrock runtime metrics (AWS/Bedrock namespace).",
+                        resolution="No action required. Review alarm thresholds and notification targets periodically to ensure they still detect abuse, throttling, and cost anomalies.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/monitoring-runtime-metrics.html",
+                        severity="Low",
+                        status="Passed",
+                        region=region,
+                    )
+                )
+            else:
+                findings["status"] = "WARN"
+                findings["details"] = "No CloudWatch alarms found on Bedrock metrics"
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-32",
+                        finding_name="Bedrock CloudWatch Alarm Check",
+                        finding_details="No CloudWatch alarms are configured on Amazon Bedrock runtime metrics (AWS/Bedrock namespace). Without alarms, abuse, denial-of-wallet, sustained throttling, and content-filter spikes can go undetected.",
+                        resolution="Create CloudWatch alarms on AWS/Bedrock runtime metrics such as Invocations, InvocationThrottles, InputTokenCount, OutputTokenCount, and ContentFilteredCount, and route them to an Amazon SNS topic for notification.",
+                        reference="https://docs.aws.amazon.com/bedrock/latest/userguide/monitoring-runtime-metrics.html",
+                        severity="Medium",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in ACCESS_DENIED_ERROR_CODES:
+                findings["csv_data"].append(
+                    create_finding(
+                        check_id="BR-32",
+                        finding_name="Bedrock CloudWatch Alarm Check",
+                        finding_details=describe_api_error(
+                            e, "CloudWatch alarm check", region
+                        ),
+                        resolution="Grant cloudwatch:DescribeAlarms permission to the assessment role",
+                        reference="https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/iam-access-control-overview-cw.html",
+                        severity="Medium",
+                        status="Failed",
+                        region=region,
+                    )
+                )
+            else:
+                raise
+
+        return findings
+
+    except Exception as e:
+        logger.error(
+            f"Error in check_bedrock_cloudwatch_alarms: {str(e)}", exc_info=True
+        )
+        return {
+            "check_name": "Bedrock CloudWatch Alarm Check",
+            "status": "ERROR",
+            "details": f"Error during check: {str(e)}",
+            "csv_data": [
+                create_finding(
+                    check_id="BR-32",
+                    finding_name="Bedrock CloudWatch Alarm Check",
+                    finding_details=f"Error during check: {str(e)}",
+                    resolution="Investigate error and retry assessment",
+                    reference="https://docs.aws.amazon.com/bedrock/latest/userguide/monitoring-runtime-metrics.html",
+                    severity="Medium",
+                    status="Failed",
+                    region=region,
+                )
+            ],
+        }
+
+
 def generate_csv_report(findings: List[Dict[str, Any]]) -> str:
     """
     Generate CSV report from all security check findings
@@ -2878,6 +6073,102 @@ def lambda_handler(event, context):
         logger.info("Running Bedrock Flows guardrails check")
         flows_guardrails_findings = check_bedrock_flows_guardrails(region=region)
         all_findings.append(flows_guardrails_findings)
+
+        # New security checks (BR-15+)
+        # BR-15 is a global check (runs once on primary region)
+        if is_primary_region:
+            logger.info("Running cross-account guardrails enforcement check (BR-15)")
+            cross_account_guardrails_findings = check_bedrock_cross_account_guardrails(
+                region=GLOBAL_REGION_LABEL
+            )
+            all_findings.append(cross_account_guardrails_findings)
+
+        # Regional checks (BR-16 through BR-25)
+        logger.info("Running guardrail tier validation check (BR-16)")
+        guardrail_tier_findings = check_bedrock_guardrail_tier(region=region)
+        all_findings.append(guardrail_tier_findings)
+
+        logger.info(
+            "Running custom model customer-managed KMS encryption check (BR-17)"
+        )
+        custom_model_kms_findings = check_bedrock_custom_model_kms_encryption(
+            region=region
+        )
+        all_findings.append(custom_model_kms_findings)
+
+        logger.info("Running model evaluation implementation check (BR-18)")
+        model_eval_findings = check_bedrock_model_evaluations(region=region)
+        all_findings.append(model_eval_findings)
+
+        logger.info("Running prompt flow validation check (BR-19)")
+        prompt_flow_findings = check_bedrock_prompt_flow_validation(region=region)
+        all_findings.append(prompt_flow_findings)
+
+        logger.info(
+            "Running knowledge base customer-managed KMS encryption check (BR-20)"
+        )
+        kb_kms_findings = check_bedrock_knowledge_base_kms_encryption(region=region)
+        all_findings.append(kb_kms_findings)
+
+        logger.info("Running agent action group IAM least privilege check (BR-21)")
+        agent_action_group_iam_findings = check_bedrock_agent_action_group_iam(
+            region=region, permission_cache=permission_cache
+        )
+        all_findings.append(agent_action_group_iam_findings)
+
+        logger.info("Running service quotas throttling limits check (BR-22)")
+        service_quotas_findings = check_bedrock_service_quotas_throttling(region=region)
+        all_findings.append(service_quotas_findings)
+
+        logger.info("Running guardrail content filter coverage check (BR-23)")
+        content_filter_findings = check_bedrock_guardrail_content_filters(region=region)
+        all_findings.append(content_filter_findings)
+
+        logger.info("Running automated reasoning policy implementation check (BR-24)")
+        automated_reasoning_findings = check_bedrock_automated_reasoning_policy(
+            region=region
+        )
+        all_findings.append(automated_reasoning_findings)
+
+        logger.info("Running RAG evaluation jobs check (BR-25)")
+        rag_eval_findings = check_bedrock_rag_evaluation_jobs(region=region)
+        all_findings.append(rag_eval_findings)
+
+        logger.info("Running guardrail sensitive-information filter check (BR-26)")
+        guardrail_pii_findings = check_bedrock_guardrail_pii_filters(region=region)
+        all_findings.append(guardrail_pii_findings)
+
+        logger.info("Running guardrail contextual grounding check (BR-27)")
+        guardrail_grounding_findings = check_bedrock_guardrail_contextual_grounding(
+            region=region
+        )
+        all_findings.append(guardrail_grounding_findings)
+
+        logger.info("Running agent guardrail association check (BR-28)")
+        agent_guardrail_findings = check_bedrock_agent_guardrail_association(
+            region=region
+        )
+        all_findings.append(agent_guardrail_findings)
+
+        logger.info("Running agent idle session TTL check (BR-29)")
+        agent_ttl_findings = check_bedrock_agent_idle_session_ttl(region=region)
+        all_findings.append(agent_ttl_findings)
+
+        logger.info("Running imported model KMS encryption check (BR-30)")
+        imported_model_findings = check_bedrock_imported_model_kms_encryption(
+            region=region
+        )
+        all_findings.append(imported_model_findings)
+
+        logger.info("Running batch inference output encryption check (BR-31)")
+        batch_inference_findings = check_bedrock_batch_inference_output_encryption(
+            region=region
+        )
+        all_findings.append(batch_inference_findings)
+
+        logger.info("Running CloudWatch alarm check (BR-32)")
+        cloudwatch_alarm_findings = check_bedrock_cloudwatch_alarms(region=region)
+        all_findings.append(cloudwatch_alarm_findings)
 
         # Generate and upload report
         logger.info("Generating CSV report")

--- a/aiml-security-assessment/functions/security/cleanup_bucket/requirements.txt
+++ b/aiml-security-assessment/functions/security/cleanup_bucket/requirements.txt
@@ -1,1 +1,2 @@
-boto3
+boto3==1.43.32
+botocore==1.43.32

--- a/aiml-security-assessment/functions/security/finserv_assessments/requirements.txt
+++ b/aiml-security-assessment/functions/security/finserv_assessments/requirements.txt
@@ -1,13 +1,16 @@
 # FinServ Security Assessment Lambda — runtime dependencies
 #
-# These pins are scanned by ASH (Automated Security Helper) via Grype + Syft
-# during the pre-PR security scan. Keep versions current; if ASH reports a
-# CVE against any pinned dep, bump to the patched version before opening the
-# PR. See GIT_WORKFLOW.md Step 5 for the ASH workflow.
+# These deps are scanned by ASH (Automated Security Helper) via Grype + Syft
+# during the pre-PR security scan. boto3/botocore use >= floors (not exact
+# pins) so the Lambda can resolve security patches; the floor must stay at or
+# above the minimum required by FS-03/FS-06 (see TestRequirementVersionFloors).
+# Keep versions current; if ASH reports a CVE against any dep, bump the floor
+# to the patched version before opening the PR. See GIT_WORKFLOW.md Step 5 for
+# the ASH workflow.
 #
 # Dev tooling (ruff, cfn-lint, ash, sam) is NOT pinned here — install those
 # in your development environment, not into the Lambda image.
 
-boto3>=1.43.21
-botocore>=1.43.21
+boto3>=1.43.32
+botocore>=1.43.32
 pydantic>=2.0.0,<3.0.0

--- a/aiml-security-assessment/functions/security/generate_consolidated_report/requirements.txt
+++ b/aiml-security-assessment/functions/security/generate_consolidated_report/requirements.txt
@@ -1,1 +1,3 @@
+boto3==1.43.32
+botocore==1.43.32
 beautifulsoup4==4.13.4

--- a/aiml-security-assessment/functions/security/iam_permission_caching/requirements.txt
+++ b/aiml-security-assessment/functions/security/iam_permission_caching/requirements.txt
@@ -1,1 +1,3 @@
+boto3==1.43.32
+botocore==1.43.32
 pydantic

--- a/aiml-security-assessment/functions/security/resolve_regions/requirements.txt
+++ b/aiml-security-assessment/functions/security/resolve_regions/requirements.txt
@@ -1,3 +1,2 @@
 boto3==1.43.32
 botocore==1.43.32
-pydantic

--- a/aiml-security-assessment/functions/security/sagemaker_assessments/requirements.txt
+++ b/aiml-security-assessment/functions/security/sagemaker_assessments/requirements.txt
@@ -1,1 +1,3 @@
+boto3==1.43.32
+botocore==1.43.32
 pydantic

--- a/aiml-security-assessment/template-multi-account.yaml
+++ b/aiml-security-assessment/template-multi-account.yaml
@@ -238,6 +238,12 @@ Resources:
               Action:
                 - cloudwatch:DescribeAlarms
               Resource: '*'
+            - Sid: OrganizationsPermissions
+              Effect: Allow
+              Action:
+                - organizations:DescribeOrganization # BR-15
+                - organizations:ListPolicies # BR-15
+              Resource: '*'
             - Sid: S3BucketEncryptionPermissions
               Effect: Allow
               Action:

--- a/aiml-security-assessment/template-multi-account.yaml
+++ b/aiml-security-assessment/template-multi-account.yaml
@@ -221,6 +221,22 @@ Resources:
                 - bedrock:GetFlow
                 - bedrock:ListKnowledgeBases
                 - bedrock:GetKnowledgeBase
+                - bedrock:ListEvaluationJobs # BR-18
+                - bedrock:ListImportedModels # BR-30
+                - bedrock:GetImportedModel # BR-30
+                - bedrock:ListAgentActionGroups
+                - bedrock:GetAgentActionGroup
+              Resource: '*'
+            - Sid: ServiceQuotasPermissions
+              Effect: Allow
+              Action:
+                - servicequotas:ListServiceQuotas # BR-22
+                - servicequotas:GetServiceQuota # BR-22
+              Resource: '*'
+            - Sid: CloudWatchPermissions
+              Effect: Allow
+              Action:
+                - cloudwatch:DescribeAlarms
               Resource: '*'
             - Sid: S3BucketEncryptionPermissions
               Effect: Allow

--- a/aiml-security-assessment/template.yaml
+++ b/aiml-security-assessment/template.yaml
@@ -237,6 +237,12 @@ Resources:
               Action:
                 - cloudwatch:DescribeAlarms
               Resource: '*'
+            - Sid: OrganizationsPermissions
+              Effect: Allow
+              Action:
+                - organizations:DescribeOrganization # BR-15
+                - organizations:ListPolicies # BR-15
+              Resource: '*'
             - Sid: S3BucketEncryptionPermissions
               Effect: Allow
               Action:

--- a/aiml-security-assessment/template.yaml
+++ b/aiml-security-assessment/template.yaml
@@ -219,6 +219,23 @@ Resources:
                 - bedrock:GetFlow
                 - bedrock:ListKnowledgeBases
                 - bedrock:GetKnowledgeBase
+                - bedrock:ListEvaluationJobs # BR-18
+                - bedrock:ListImportedModels # BR-30
+                - bedrock:GetImportedModel # BR-30
+                - bedrock:ListModelInvocationJobs # BR-31
+                - bedrock:ListAgentActionGroups
+                - bedrock:GetAgentActionGroup
+              Resource: '*'
+            - Sid: ServiceQuotasPermissions
+              Effect: Allow
+              Action:
+                - servicequotas:ListServiceQuotas # BR-22
+                - servicequotas:GetServiceQuota # BR-22
+              Resource: '*'
+            - Sid: CloudWatchPermissions
+              Effect: Allow
+              Action:
+                - cloudwatch:DescribeAlarms
               Resource: '*'
             - Sid: S3BucketEncryptionPermissions
               Effect: Allow

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,4 +1,8 @@
 version: 0.2
+env:
+  variables:
+    # Opt out of AWS SAM CLI telemetry collection for all phases.
+    SAM_CLI_TELEMETRY: "0"
 phases:
   install:
     runtime-versions:

--- a/deployment/1-aiml-security-member-roles.yaml
+++ b/deployment/1-aiml-security-member-roles.yaml
@@ -73,6 +73,13 @@ Resources:
                   - bedrock:GetModelCustomizationJob
                   - bedrock:ListFlows
                   - bedrock:GetFlow
+                  # Model evaluation (BR-18, BR-25)
+                  - bedrock:ListEvaluationJobs
+                  # Imported custom models (BR-30)
+                  - bedrock:ListImportedModels
+                  - bedrock:GetImportedModel
+                  # Batch inference jobs (BR-31)
+                  - bedrock:ListModelInvocationJobs
                 Resource: "*"
               # Bedrock Agent Permissions (Agents for Amazon Bedrock)
               - Effect: Allow
@@ -83,6 +90,21 @@ Resources:
                   - bedrock:GetAgent
                   - bedrock:ListKnowledgeBases
                   - bedrock:GetKnowledgeBase
+                  # Agent action groups (BR-21)
+                  - bedrock:ListAgentActionGroups
+                  - bedrock:GetAgentActionGroup
+                Resource: "*"
+              # Bedrock cross-account / quota / monitoring assessment
+              # (BR-15 organizational guardrails, BR-22 service quotas,
+              # BR-32 CloudWatch alarms)
+              - Effect: Allow
+                Action:
+                  - organizations:DescribeOrganization
+                  - organizations:ListRoots
+                  - organizations:ListPolicies
+                  - servicequotas:ListServiceQuotas
+                  - servicequotas:GetServiceQuota
+                  - cloudwatch:DescribeAlarms
                 Resource: "*"
               # Bedrock AgentCore Permissions
               - Effect: Allow
@@ -151,6 +173,8 @@ Resources:
               - Effect: Allow
                 Action:
                   - lambda:ListFunctions
+                  # Read agent action-group Lambda execution role (BR-21)
+                  - lambda:GetFunction
                 Resource: "*"
               # ECS Permissions
               - Effect: Allow

--- a/deployment/2-aiml-security-codebuild.yaml
+++ b/deployment/2-aiml-security-codebuild.yaml
@@ -213,6 +213,24 @@ Resources:
                   - bedrock:GetFlow
                   - bedrock:ListKnowledgeBases
                   - bedrock:GetKnowledgeBase
+                  # Model evaluation (BR-18, BR-25)
+                  - bedrock:ListEvaluationJobs
+                  # Imported custom models (BR-30)
+                  - bedrock:ListImportedModels
+                  - bedrock:GetImportedModel
+                  # Batch inference jobs (BR-31)
+                  - bedrock:ListModelInvocationJobs
+                  # Agent action groups (BR-21)
+                  - bedrock:ListAgentActionGroups
+                  - bedrock:GetAgentActionGroup
+                  # Cross-account guardrails / quotas / monitoring
+                  # (BR-15, BR-22, BR-32)
+                  - organizations:DescribeOrganization
+                  - organizations:ListRoots
+                  - organizations:ListPolicies
+                  - servicequotas:ListServiceQuotas
+                  - servicequotas:GetServiceQuota
+                  - cloudwatch:DescribeAlarms
                   # SageMaker Permissions
                   - sagemaker:ListNotebookInstances
                   - sagemaker:DescribeNotebookInstance
@@ -258,6 +276,8 @@ Resources:
                   - cloudtrail:GetEventSelectors
                   - cloudtrail:GetTrailStatus
                   - lambda:ListFunctions
+                  # Read agent action-group Lambda execution role (BR-21)
+                  - lambda:GetFunction
                   - ecs:ListClusters
                   - ecs:ListTasks
                   - ecs:DescribeTasks

--- a/deployment/aiml-security-single-account.yaml
+++ b/deployment/aiml-security-single-account.yaml
@@ -174,9 +174,27 @@ Resources:
                   - bedrock:GetModelCustomizationJob
                   - bedrock:ListFlows
                   - bedrock:GetFlow
+                  # Model evaluation (BR-18, BR-25)
+                  - bedrock:ListEvaluationJobs
+                  # Imported custom models (BR-30)
+                  - bedrock:ListImportedModels
+                  - bedrock:GetImportedModel
+                  # Batch inference jobs (BR-31)
+                  - bedrock:ListModelInvocationJobs
                   # Bedrock Agent Permissions (Knowledge Bases, Flows)
                   - bedrock:ListKnowledgeBases
                   - bedrock:GetKnowledgeBase
+                  # Agent action groups (BR-21)
+                  - bedrock:ListAgentActionGroups
+                  - bedrock:GetAgentActionGroup
+                  # Cross-account guardrails / quotas / monitoring
+                  # (BR-15, BR-22, BR-32)
+                  - organizations:DescribeOrganization
+                  - organizations:ListRoots
+                  - organizations:ListPolicies
+                  - servicequotas:ListServiceQuotas
+                  - servicequotas:GetServiceQuota
+                  - cloudwatch:DescribeAlarms
                   # SageMaker Permissions
                   - sagemaker:ListNotebookInstances
                   - sagemaker:DescribeNotebookInstance
@@ -222,6 +240,8 @@ Resources:
                   - cloudtrail:GetEventSelectors
                   - cloudtrail:GetTrailStatus
                   - lambda:ListFunctions
+                  # Read agent action-group Lambda execution role (BR-21)
+                  - lambda:GetFunction
                   - ecs:ListClusters
                   - ecs:ListTasks
                   - ecs:DescribeTasks

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -44,7 +44,7 @@
 
 ## Architecture Overview
 
-The AI/ML Security Assessment Framework is a serverless, multi-account security assessment solution for AWS AI/ML workloads. It performs 52 core security checks across Amazon Bedrock, Amazon SageMaker AI, and Amazon Bedrock AgentCore, with an optional 64-check Financial Services GenAI risk assessment, generating interactive HTML reports with findings and remediation guidance.
+The AI/ML Security Assessment Framework is a serverless, multi-account security assessment solution for AWS AI/ML workloads. It performs 70 core security checks across Amazon Bedrock, Amazon SageMaker AI, and Amazon Bedrock AgentCore, with an optional 64-check Financial Services GenAI risk assessment, generating interactive HTML reports with findings and remediation guidance.
 
 ### Security Design Principles
 
@@ -211,7 +211,7 @@ sample-aiml-security-assessment/
 
 ## Assessment Structure
 
-The framework includes **52 core security checks** across three AI/ML services, plus **64 optional Financial Services GenAI risk checks** when `EnableFinServAssessment` is enabled. For the complete list of checks with descriptions, see the [Security Checks Reference](SECURITY_CHECKS.md).
+The framework includes **70 core security checks** across three AI/ML services, plus **64 optional Financial Services GenAI risk checks** when `EnableFinServAssessment` is enabled. For the complete list of checks with descriptions, see the [Security Checks Reference](SECURITY_CHECKS.md).
 
 ### AWS Lambda Functions
 
@@ -560,7 +560,7 @@ For detailed troubleshooting guidance, common issues, and debugging tips, see th
 ## Development Roadmap
 
 ### Current Status
-- **AI/ML Assessment**: 52 core checks across three services, plus 64 optional Financial Services GenAI risk checks (see [Security Checks Reference](SECURITY_CHECKS.md))
+- **AI/ML Assessment**: 70 core checks across three services, plus 64 optional Financial Services GenAI risk checks (see [Security Checks Reference](SECURITY_CHECKS.md))
 
 ### Potential Additions
 - **Amazon Comprehend**: Data privacy, access controls, entity recognition security

--- a/docs/SECURITY_CHECKS.md
+++ b/docs/SECURITY_CHECKS.md
@@ -1,6 +1,6 @@
 # Security Checks Reference
 
-This document provides a comprehensive reference for all 116 security checks performed by the AI/ML Security Assessment framework (52 core checks across Amazon Bedrock, Amazon SageMaker AI, and Amazon Bedrock AgentCore, plus 64 Financial Services GenAI Risk checks).
+This document provides a comprehensive reference for all 134 security checks performed by the AI/ML Security Assessment framework (70 core checks across Amazon Bedrock, Amazon SageMaker AI, and Amazon Bedrock AgentCore, plus 64 Financial Services GenAI Risk checks).
 
 ## Table of Contents
 
@@ -9,7 +9,7 @@ This document provides a comprehensive reference for all 116 security checks per
 - [Severity Levels](#severity-levels)
 - [Status Values](#status-values)
 - [Amazon SageMaker AI Security Checks (25)](#amazon-sagemaker-ai-security-checks-25)
-- [Amazon Bedrock Security Checks (14)](#amazon-bedrock-security-checks-14)
+- [Amazon Bedrock Security Checks (32)](#amazon-bedrock-security-checks-32)
 - [Amazon Bedrock AgentCore Security Checks (13)](#amazon-bedrock-agentcore-security-checks-13)
 - [Financial Services GenAI Risk Checks (64)](#financial-services-genai-risk-checks-64-additional-5-upstream-extensions)
 
@@ -22,7 +22,7 @@ The framework evaluates your AI/ML workloads against AWS security best practices
 | Service | Number of Checks | Focus Areas |
 |---------|------------------|-------------|
 | Amazon SageMaker AI | 25 | Security Hub controls, encryption, network isolation, IAM, MLOps |
-| Amazon Bedrock | 14 | Guardrails, encryption, VPC endpoints, IAM permissions, logging |
+| Amazon Bedrock | 32 | Guardrails, content filters, sensitive-information/PII filters, contextual grounding, automated reasoning, encryption (custom, imported, knowledge base, batch inference output), VPC endpoints, IAM permissions, agent guardrail association and least privilege, logging, CloudWatch alarms, cross-account policies, model evaluation, prompt flow validation, RAG evaluation, service quotas |
 | Amazon Bedrock AgentCore | 13 | VPC configuration, encryption, observability, resource policies |
 | Financial Services GenAI Risk | 64 | Unbounded consumption, excessive agency, supply chain, training data poisoning, vector weaknesses, non-compliant output, misinformation, harmful output, biased output, PII disclosure, hallucination, prompt injection, improper output handling, off-topic output, out-of-date training data |
 
@@ -35,7 +35,7 @@ Each security check has a unique identifier with a service prefix:
 | Prefix | Service | Example |
 |--------|---------|---------|
 | **SM-XX** | Amazon SageMaker | SM-01, SM-25 |
-| **BR-XX** | Amazon Bedrock | BR-01, BR-14 |
+| **BR-XX** | Amazon Bedrock | BR-01, BR-32 |
 | **AC-XX** | Amazon Bedrock AgentCore | AC-01, AC-13 |
 | **FS-XX** | Financial Services GenAI Risk | FS-01, FS-69 |
 
@@ -198,7 +198,7 @@ Each security check has a unique identifier with a service prefix:
 
 ---
 
-## Amazon Bedrock Security Checks (14)
+## Amazon Bedrock Security Checks (32)
 
 ### BR-01: AWS IAM Least Privilege
 
@@ -269,6 +269,114 @@ Each security check has a unique identifier with a service prefix:
 
 - **Severity:** Medium
 - **Description:** Detects principals with Bedrock permissions that have not used the service recently, using IAM service-last-accessed data. As an IAM-global check, it runs once per execution and is tagged with the `Global` region in multi-region scans.
+
+### BR-15: Cross-Account Guardrails Enforcement
+
+- **Severity:** High
+- **Type:** Global (runs once)
+- **Description:** Verifies organization-level guardrails are configured using AWS Organizations Amazon Bedrock policies (the `BEDROCK_POLICY` policy type) for centralized safety control enforcement across all accounts. Checks if running in the AWS Organizations management account, validates the Bedrock policy type is enabled at the organization root, and verifies that Bedrock policies are attached.
+
+### BR-16: Guardrail Tier Validation
+
+- **Severity:** Medium
+- **Type:** Regional
+- **Description:** Verifies guardrails use the `STANDARD` content-filter tier (vs the `CLASSIC` tier) for enhanced protection and broader language support. Lists all guardrails in the region and inspects each guardrail's `contentPolicy.tier.tierName`. The STANDARD tier requires cross-Region inference.
+
+### BR-17: Custom Model Customer-Managed KMS Encryption
+
+- **Severity:** High
+- **Type:** Regional
+- **Description:** Verifies fine-tuned/customized models use customer-managed KMS keys instead of AWS-owned keys for greater control over encryption. Lists all custom models, retrieves model details to check KMS key configuration, and validates KMS key ARN format. This extends the existing BR-11 check by specifically verifying the type of encryption key used.
+
+### BR-18: Model Evaluation Implementation
+
+- **Severity:** Medium
+- **Type:** Regional
+- **Description:** Checks if model evaluation jobs exist to assess safety metrics (toxicity, accuracy, semantic robustness) before production deployment. Lists all model evaluation jobs, identifies recent evaluations (completed within 30 days), and analyzes evaluation configurations for safety metrics.
+
+### BR-19: Prompt Flow Validation
+
+- **Severity:** Medium
+- **Type:** Regional
+- **Description:** Verifies Bedrock Agents prompt flows are validated using `validate_flow_definition` API before deployment to prevent misconfigured flows. Lists all flows in the region, checks for validation records or status, identifies unvalidated flows, and reports flows deployed without validation.
+
+### BR-20: Knowledge Base Encryption Enhancement
+
+- **Severity:** High
+- **Type:** Regional
+- **Description:** Extends existing BR-09 to verify Knowledge Base encryption uses customer-managed KMS keys. Uses the authoritative knowledge base `type` (`VECTOR | KENDRA | SQL | MANAGED`) to decide how to assess each KB: for `MANAGED` knowledge bases it reads `knowledgeBaseConfiguration.managedKnowledgeBaseConfiguration.serverSideEncryptionConfiguration.kmsKeyArn` and fails KBs encrypted with an AWS-owned key; for custom vector stores (OpenSearch, RDS, Pinecone, etc.) the encryption key lives on the underlying storage resource and cannot be read from the KB API, so those are reported as N/A for manual review. If a `MANAGED` KB's encryption block is missing from the API response (deployed botocore older than 1.43.32, which silently drops the unmodeled field), the KB is reported as N/A "indeterminate" rather than a false-positive failure.
+
+### BR-21: Agent Action Group IAM Least Privilege
+
+- **Severity:** High
+- **Type:** Regional
+- **Description:** Extends existing BR-08 to specifically check if Bedrock Agent action groups use scoped Lambda execution roles with minimal permissions. Enumerates agents and their action groups, retrieves Lambda execution roles for each action group, analyzes IAM policies for overly broad permissions (AdministratorAccess, FullAccess, Resource: "*"), and verifies principle of least privilege.
+
+### BR-22: Model Invocation Throttling Limits
+
+- **Severity:** Medium
+- **Type:** Regional
+- **Description:** Verifies service quotas are configured for model invocation throttling to prevent abuse/DoS and control costs. Queries Service Quotas for Bedrock, checks if custom limits are set for on-demand model invocation TPM (tokens per minute), provisioned throughput limits, and concurrent requests. Reports accounts relying solely on default quotas.
+
+### BR-23: Guardrail Content Filter Coverage
+
+- **Severity:** High
+- **Type:** Regional
+- **Description:** Extends existing BR-05 to verify guardrails have ALL content filters enabled (hate, insults, sexual, violence) with appropriate thresholds. For each guardrail, checks content filter configuration for all four filter types, verifies filter thresholds are configured, and reports missing or misconfigured filters.
+
+### BR-24: Automated Reasoning Policy Implementation
+
+- **Severity:** Medium
+- **Type:** Regional
+- **Description:** Checks if Automated Reasoning policies are configured on guardrails for formal verification of model responses. Enumerates guardrails, checks for Automated Reasoning policy configuration, validates policy syntax and enabled state, and reports guardrails without formal verification capability.
+
+### BR-25: RAG Evaluation Jobs
+
+- **Severity:** Low
+- **Type:** Regional
+- **Description:** Verifies RAG applications have evaluation jobs configured to assess context relevance, response correctness, and prevent hallucinations. Lists Knowledge Bases, checks for associated RAG evaluation jobs for each KB, verifies evaluation metrics include context relevance, response correctness, faithfulness, and harmfulness checks. Reports KBs without evaluation jobs.
+
+### BR-26: Guardrail Sensitive Information Filter
+
+- **Severity:** High
+- **Type:** Regional
+- **Description:** Extends BR-23 (which covers the harmful-content filters) to verify guardrails configure sensitive-information protection. For each guardrail, reads `GetGuardrail.sensitiveInformationPolicy` and reports guardrails that have no PII entity types (`piiEntities`) or custom regex patterns (`regexes`) configured, leaving prompts and responses unscreened for sensitive data.
+
+### BR-27: Guardrail Contextual Grounding Check
+
+- **Severity:** Medium
+- **Type:** Regional
+- **Description:** Verifies guardrails enable contextual grounding checks to detect hallucinated (ungrounded) and off-topic model responses. Reads `GetGuardrail.contextualGroundingPolicy.filters` and reports guardrails with no enabled grounding/relevance filters. Complements BR-25 (RAG evaluation) with a runtime control.
+
+### BR-28: Agent Guardrail Association
+
+- **Severity:** High
+- **Type:** Regional
+- **Description:** Verifies each Bedrock Agent has a guardrail associated so agent interactions are subject to content filtering, PII protection, and denied-topic controls. Reads `guardrailConfiguration` from the agent summaries returned by `ListAgents` and reports agents with no guardrail attached.
+
+### BR-29: Agent Idle Session TTL
+
+- **Severity:** Low
+- **Type:** Regional
+- **Description:** Verifies Bedrock Agents do not use an excessively long idle session TTL, which widens the window for session and conversation-context reuse. Reads `GetAgent.idleSessionTTLInSeconds` and reports agents whose TTL exceeds a conservative ceiling (3600 seconds).
+
+### BR-30: Imported Model Customer-Managed KMS Encryption
+
+- **Severity:** High
+- **Type:** Regional
+- **Description:** Complements BR-11/BR-17 by verifying imported custom models use customer-managed KMS keys. Lists imported models and reads `GetImportedModel.modelKmsKeyArn`, reporting models encrypted with AWS-owned keys instead of a customer-managed key.
+
+### BR-31: Batch Inference Output Encryption
+
+- **Severity:** Medium
+- **Type:** Regional
+- **Description:** Verifies batch inference (model invocation) jobs encrypt their S3 output with a customer-managed KMS key. Reads `outputDataConfig.s3OutputDataConfig.s3EncryptionKeyId` from the job summaries returned by `ListModelInvocationJobs` and reports jobs without a customer-managed output key.
+
+### BR-32: CloudWatch Alarms on Bedrock Metrics
+
+- **Severity:** Medium
+- **Type:** Regional
+- **Description:** Verifies CloudWatch alarms exist on Amazon Bedrock runtime metrics (the `AWS/Bedrock` namespace) to detect abuse, denial-of-wallet, sustained throttling, and content-filter spikes. Uses `DescribeAlarms` and matches alarms that target the `AWS/Bedrock` namespace directly or via a metric-math expression. Only assessed in regions that have Bedrock resources.
 
 ---
 

--- a/docs/SECURITY_CHECKS_FINSERV.md
+++ b/docs/SECURITY_CHECKS_FINSERV.md
@@ -136,7 +136,7 @@ Because `aws-samples` is an OSPO-managed organization, pushes to your personal f
 ## Relationship to upstream SM/BR/AC checks
 
 The upstream [sample-aiml-security-assessment](https://github.com/aws-samples/sample-aiml-security-assessment)
-framework already provides 52 core security checks (SM-01 to SM-25, BR-01 to BR-14, AC-01 to AC-13).
+framework already provides 70 core security checks (SM-01 to SM-25, BR-01 to BR-32, AC-01 to AC-13).
 The 69 FS checks in this document are **additive**: they enhance the upstream with FinServ-specific
 detection and remediation guidance drawn from the Responsible AI GRC guide. A few FS
 checks overlap with upstream checks — in those cases, the FS check adds FinServ-specific depth
@@ -179,7 +179,7 @@ whether the FS check adds FinServ-specific regulatory specificity, (3) severity 
 - **Extend upstream (5 FS checks merged into 5 upstream checks):** FS-17 → SM-07; FS-18 → SM-23; FS-19 → SM-22; FS-23 → BR-06; FS-64 → BR-04. These checks are replaced by upstream-extension notes in Parts 1 and 3 and are removed from `finserv_assessments/app.py`.
 - **Keep separate (64 FS checks):** All other FS checks ship as standalone entries. This includes FS-20, FS-22, FS-25, FS-26, FS-39, FS-41, all Guardrail-policy-level checks (FS-27, FS-28, FS-36, FS-38, FS-45, FS-47, FS-50, FS-51, FS-59), and all FS checks that have no upstream overlap at all.
 
-After consolidation the combined framework contains **52 upstream + 64 FS = 116 distinct checks** (down from 52 + 69 = 121 before merging). The consolidation reduces duplication without losing FinServ-specific regulatory depth.
+After consolidation the combined framework contains **70 upstream + 64 FS = 134 distinct checks** (down from 70 + 69 = 139 before merging). The consolidation reduces duplication without losing FinServ-specific regulatory depth.
 
 
 ---

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -323,7 +323,7 @@ A: Minimal ongoing costs:
 
 **Q: Can I customize which security checks are included?**
 
-A: Currently, all 52 core checks run by default to provide comprehensive coverage. If `EnableFinServAssessment` is enabled, the 64 optional Financial Services GenAI risk checks also run. You can filter results in the generated HTML reports by severity, status, service, industry, or region. Future versions may support selective check execution.
+A: Currently, all 70 core checks run by default to provide comprehensive coverage. If `EnableFinServAssessment` is enabled, the 64 optional Financial Services GenAI risk checks also run. You can filter results in the generated HTML reports by severity, status, service, industry, or region. Future versions may support selective check execution.
 
 **Q: Can I add custom security checks?**
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,6 +2,6 @@ pytest>=7.4.0
 pytest-cov>=4.1.0
 pytest-mock>=3.11.0
 moto[all]>=4.2.0
-boto3>=1.28.0
-botocore>=1.31.0
+boto3==1.43.32
+botocore==1.43.32
 pydantic>=2.0.0

--- a/tests/test_bedrock_checks.py
+++ b/tests/test_bedrock_checks.py
@@ -9,6 +9,7 @@ Each check is tested for:
 - Output schema validity
 """
 
+import contextlib
 import sys
 import os
 import importlib.util
@@ -1375,3 +1376,1618 @@ class TestBedrockHandlerMultiRegion:
         # checks ran (e.g. BR-04 logging, BR-05 guardrails are present).
         assert "BR-00" not in check_ids
         assert len(check_ids) > 3
+
+    # Regional checks BR-26..32 (function name -> check id) that the handler must
+    # invoke once per scanned region, passing region=region.
+    NEW_REGIONAL_CHECKS = {
+        "check_bedrock_guardrail_pii_filters": "BR-26",
+        "check_bedrock_guardrail_contextual_grounding": "BR-27",
+        "check_bedrock_agent_guardrail_association": "BR-28",
+        "check_bedrock_agent_idle_session_ttl": "BR-29",
+        "check_bedrock_imported_model_kms_encryption": "BR-30",
+        "check_bedrock_batch_inference_output_encryption": "BR-31",
+        "check_bedrock_cloudwatch_alarms": "BR-32",
+    }
+
+    def _run_handler_with_check_spies(self, event):
+        """Drive the handler down the full regional path with every check function
+        replaced by a spy that records the region it was called with. The probe
+        raises ValidationException (service reachable) so all regional checks run.
+        Returns {check_function_name: region_passed} plus whether BR-15 ran."""
+        recorded = {}
+
+        def make_spy(name):
+            def spy(*args, region="", **kwargs):
+                recorded[name] = region
+                return {
+                    "check_name": name,
+                    "status": "PASS",
+                    "details": "",
+                    "csv_data": [],
+                }
+
+            return spy
+
+        test_client = MagicMock()
+        test_client.get_model_invocation_logging_configuration.side_effect = (
+            _make_client_error("ValidationException")
+        )
+
+        # Spy on every check the handler calls so it runs cleanly end-to-end.
+        spied = [
+            "check_bedrock_full_access_roles",
+            "check_marketplace_subscription_access",
+            "check_bedrock_access_and_vpc_endpoints",
+            "check_bedrock_logging_configuration",
+            "check_bedrock_guardrails",
+            "check_bedrock_cloudtrail_logging",
+            "check_bedrock_prompt_management",
+            "check_bedrock_agent_roles",
+            "check_bedrock_knowledge_base_encryption",
+            "check_bedrock_guardrail_iam_enforcement",
+            "check_bedrock_custom_model_encryption",
+            "check_bedrock_invocation_log_encryption",
+            "check_bedrock_flows_guardrails",
+            "check_bedrock_cross_account_guardrails",  # BR-15 (global)
+            "check_bedrock_guardrail_tier",
+            "check_bedrock_custom_model_kms_encryption",
+            "check_bedrock_model_evaluations",
+            "check_bedrock_prompt_flow_validation",
+            "check_bedrock_knowledge_base_kms_encryption",
+            "check_bedrock_agent_action_group_iam",
+            "check_bedrock_service_quotas_throttling",
+            "check_bedrock_guardrail_content_filters",
+            "check_bedrock_automated_reasoning_policy",
+            "check_bedrock_rag_evaluation_jobs",
+            *self.NEW_REGIONAL_CHECKS.keys(),
+        ]
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(
+                patch.object(bedrock_app.boto3, "client", return_value=test_client)
+            )
+            stack.enter_context(
+                patch.object(
+                    bedrock_app,
+                    "get_permissions_cache",
+                    return_value={"role_permissions": {}, "user_permissions": {}},
+                )
+            )
+            stack.enter_context(
+                patch.object(bedrock_app, "generate_csv_report", return_value="csv")
+            )
+            stack.enter_context(
+                patch.object(bedrock_app, "write_to_s3", return_value="s3://b/r.csv")
+            )
+            for name in spied:
+                stack.enter_context(
+                    patch.object(bedrock_app, name, side_effect=make_spy(name))
+                )
+            resp = bedrock_app.lambda_handler(event, None)
+
+        return resp, recorded
+
+    def test_new_regional_checks_run_per_region_non_primary(self):
+        # On a non-primary region, BR-26..32 must each run with region=<scanned>,
+        # and the global BR-15 check must NOT run.
+        resp, recorded = self._run_handler_with_check_spies(
+            _bedrock_event(region="eu-west-3", region_index=2)
+        )
+        assert resp["statusCode"] == 200
+        for fn_name in self.NEW_REGIONAL_CHECKS:
+            assert recorded.get(fn_name) == "eu-west-3", (
+                f"{fn_name} not run with scanned region: {recorded.get(fn_name)}"
+            )
+        # BR-15 (cross-account guardrails) is global -> skipped on non-primary.
+        assert "check_bedrock_cross_account_guardrails" not in recorded
+
+    def test_new_regional_checks_run_per_region_primary(self):
+        # On the primary region, BR-26..32 run with region=<scanned> and the
+        # global BR-15 check runs tagged Global.
+        resp, recorded = self._run_handler_with_check_spies(
+            _bedrock_event(region="us-east-1", region_index=0)
+        )
+        assert resp["statusCode"] == 200
+        for fn_name in self.NEW_REGIONAL_CHECKS:
+            assert recorded.get(fn_name) == "us-east-1", (
+                f"{fn_name} not run with scanned region: {recorded.get(fn_name)}"
+            )
+        # Global check runs once, tagged Global.
+        assert recorded.get("check_bedrock_cross_account_guardrails") == "Global"
+
+
+# ===================================================================
+# BR-15: check_bedrock_cross_account_guardrails
+# ===================================================================
+class TestBR15CrossAccountGuardrails:
+    """BR-15: Check AWS Organizations Bedrock Guardrails policies."""
+
+    @patch("bedrock_app.boto3.client")
+    def test_br15_organizations_not_enabled_returns_na(self, mock_client):
+        check = bedrock_app.check_bedrock_cross_account_guardrails
+
+        org_client = MagicMock()
+        org_client.describe_organization.side_effect = ClientError(
+            {"Error": {"Code": "AWSOrganizationsNotInUseException"}},
+            "DescribeOrganization",
+        )
+        mock_client.return_value = org_client
+
+        result = check(region="Global")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-15"
+        assert "not in use" in findings[0]["Finding_Details"]
+
+    @patch("bedrock_app.boto3.client")
+    def test_br15_policy_type_not_enabled_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_cross_account_guardrails
+
+        org_client = MagicMock()
+        org_client.describe_organization.return_value = {
+            "Organization": {"MasterAccountId": "123456789012"}
+        }
+        org_client.list_roots.return_value = {
+            "Roots": [
+                {
+                    "Id": "r-abc123",
+                    "Arn": "arn:aws:organizations::123456789012:root/o-xyz/r-abc123",
+                }
+            ]
+        }
+        # No policies returned = policy type not enabled
+        org_client.list_policies.return_value = {"Policies": []}
+
+        sts_client = MagicMock()
+        sts_client.get_caller_identity.return_value = {"Account": "123456789012"}
+
+        def client_factory(service, **kwargs):
+            if service == "organizations":
+                return org_client
+            return sts_client
+
+        mock_client.side_effect = client_factory
+
+        result = check(region="Global")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-15"
+        assert findings[0]["Severity"] == "High"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br15_policies_configured_returns_passed(self, mock_client):
+        check = bedrock_app.check_bedrock_cross_account_guardrails
+
+        org_client = MagicMock()
+        org_client.describe_organization.return_value = {
+            "Organization": {"MasterAccountId": "123456789012"}
+        }
+        org_client.list_roots.return_value = {
+            "Roots": [
+                {
+                    "Id": "r-abc123",
+                    "Arn": "arn:aws:organizations::123456789012:root/o-xyz/r-abc123",
+                    "PolicyTypes": [{"Type": "BEDROCK_POLICY", "Status": "ENABLED"}],
+                }
+            ]
+        }
+        org_client.list_policies.return_value = {
+            "Policies": [{"Id": "p-123", "Name": "BedrockGuardrailPolicy"}]
+        }
+
+        sts_client = MagicMock()
+        sts_client.get_caller_identity.return_value = {"Account": "123456789012"}
+
+        def client_factory(service, **kwargs):
+            if service == "organizations":
+                return org_client
+            return sts_client
+
+        mock_client.side_effect = client_factory
+
+        result = check(region="Global")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        passed_findings = [f for f in findings if f["Status"] == "Passed"]
+        assert len(passed_findings) >= 1
+        assert passed_findings[0]["Check_ID"] == "BR-15"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br15_access_denied_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_cross_account_guardrails
+
+        org_client = MagicMock()
+        org_client.describe_organization.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException"}}, "DescribeOrganization"
+        )
+        mock_client.return_value = org_client
+
+        result = check(region="Global")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-15"
+
+    def test_br15_schema_valid(self):
+        check = bedrock_app.check_bedrock_cross_account_guardrails
+        with patch("bedrock_app.boto3.client") as mock_client:
+            org_client = MagicMock()
+            org_client.describe_organization.side_effect = ClientError(
+                {"Error": {"Code": "AWSOrganizationsNotInUseException"}},
+                "DescribeOrganization",
+            )
+            mock_client.return_value = org_client
+            result = check(region="Global")
+
+        for f in extract_csv_data(result):
+            assert_finding_schema(f)
+
+
+# ===================================================================
+# BR-16: check_bedrock_guardrail_tier
+# ===================================================================
+class TestBR16GuardrailTier:
+    """BR-16: Verify guardrails use Standard tier."""
+
+    @patch("bedrock_app.boto3.client")
+    def test_br16_no_guardrails_returns_na(self, mock_client):
+        check = bedrock_app.check_bedrock_guardrail_tier
+
+        bedrock_client = MagicMock()
+        bedrock_client.list_guardrails.return_value = {"guardrails": []}
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-16"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br16_standard_tier_returns_passed(self, mock_client):
+        check = bedrock_app.check_bedrock_guardrail_tier
+
+        bedrock_client = MagicMock()
+        bedrock_client.list_guardrails.return_value = {
+            "guardrails": [{"id": "gr-123", "name": "test-guardrail"}]
+        }
+        bedrock_client.get_guardrail.return_value = {
+            "guardrail": {"contentPolicy": {"tier": {"tierName": "STANDARD"}}}
+        }
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        passed_findings = [f for f in findings if f["Status"] == "Passed"]
+        assert len(passed_findings) >= 1
+        assert passed_findings[0]["Check_ID"] == "BR-16"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br16_non_standard_tier_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_guardrail_tier
+
+        bedrock_client = MagicMock()
+        bedrock_client.list_guardrails.return_value = {
+            "guardrails": [{"id": "gr-123", "name": "classic-guardrail"}]
+        }
+        bedrock_client.get_guardrail.return_value = {
+            "guardrail": {"contentPolicy": {"tier": {"tierName": "CLASSIC"}}}
+        }
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-16"
+        assert findings[0]["Severity"] == "Medium"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br16_access_denied_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_guardrail_tier
+
+        bedrock_client = MagicMock()
+        bedrock_client.list_guardrails.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException"}}, "ListGuardrails"
+        )
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-16"
+
+    def test_br16_schema_valid(self):
+        check = bedrock_app.check_bedrock_guardrail_tier
+        with patch("bedrock_app.boto3.client") as mock_client:
+            bedrock_client = MagicMock()
+            bedrock_client.list_guardrails.return_value = {"guardrails": []}
+            mock_client.return_value = bedrock_client
+            result = check(region="us-east-1")
+
+        for f in extract_csv_data(result):
+            assert_finding_schema(f)
+
+
+# ===================================================================
+# BR-17: check_bedrock_custom_model_kms_encryption
+# ===================================================================
+class TestBR17CustomModelKMSEncryption:
+    """BR-17: Verify custom models use customer-managed KMS keys."""
+
+    @patch("bedrock_app.boto3.client")
+    def test_br17_no_custom_models_returns_na(self, mock_client):
+        check = bedrock_app.check_bedrock_custom_model_kms_encryption
+
+        bedrock_client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{"modelSummaries": []}]
+        bedrock_client.get_paginator.return_value = paginator
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-17"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br17_customer_managed_kms_returns_passed(self, mock_client):
+        check = bedrock_app.check_bedrock_custom_model_kms_encryption
+
+        bedrock_client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [
+            {
+                "modelSummaries": [
+                    {
+                        "modelArn": "arn:aws:bedrock:us-east-1:123456789012:custom-model/my-model",
+                        "modelName": "my-model",
+                    }
+                ]
+            }
+        ]
+        bedrock_client.get_paginator.return_value = paginator
+        bedrock_client.get_custom_model.return_value = {
+            "modelKmsKeyArn": "arn:aws:kms:us-east-1:123456789012:key/abc-123"
+        }
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        passed_findings = [f for f in findings if f["Status"] == "Passed"]
+        assert len(passed_findings) >= 1
+        assert passed_findings[0]["Check_ID"] == "BR-17"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br17_aws_owned_keys_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_custom_model_kms_encryption
+
+        bedrock_client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [
+            {
+                "modelSummaries": [
+                    {
+                        "modelArn": "arn:aws:bedrock:us-east-1:123456789012:custom-model/my-model",
+                        "modelName": "my-model",
+                    }
+                ]
+            }
+        ]
+        bedrock_client.get_paginator.return_value = paginator
+        # No KMS key ID = AWS-owned key
+        bedrock_client.get_custom_model.return_value = {}
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-17"
+        assert findings[0]["Severity"] == "High"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br17_access_denied_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_custom_model_kms_encryption
+
+        bedrock_client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException"}}, "ListCustomModels"
+        )
+        bedrock_client.get_paginator.return_value = paginator
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-17"
+
+    def test_br17_schema_valid(self):
+        check = bedrock_app.check_bedrock_custom_model_kms_encryption
+        with patch("bedrock_app.boto3.client") as mock_client:
+            bedrock_client = MagicMock()
+            paginator = MagicMock()
+            paginator.paginate.return_value = [{"modelSummaries": []}]
+            bedrock_client.get_paginator.return_value = paginator
+            mock_client.return_value = bedrock_client
+            result = check(region="us-east-1")
+
+        for f in extract_csv_data(result):
+            assert_finding_schema(f)
+
+
+# ===================================================================
+# BR-18: check_bedrock_model_evaluations
+# ===================================================================
+class TestBR18ModelEvaluations:
+    """BR-18: Check if model evaluation jobs exist."""
+
+    @patch("bedrock_app.boto3.client")
+    def test_br18_no_evaluations_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_model_evaluations
+
+        bedrock_client = MagicMock()
+        bedrock_client.list_evaluation_jobs.return_value = {"jobSummaries": []}
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-18"
+        assert findings[0]["Severity"] == "Medium"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br18_recent_evaluations_returns_passed(self, mock_client):
+        check = bedrock_app.check_bedrock_model_evaluations
+
+        from datetime import datetime, timezone, timedelta
+
+        recent_time = datetime.now(timezone.utc) - timedelta(days=10)
+
+        bedrock_client = MagicMock()
+        bedrock_client.list_evaluation_jobs.return_value = {
+            "jobSummaries": [
+                {
+                    "jobName": "eval-job-1",
+                    "status": "Completed",
+                    "creationTime": recent_time,
+                }
+            ]
+        }
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        passed_findings = [f for f in findings if f["Status"] == "Passed"]
+        assert len(passed_findings) >= 1
+        assert passed_findings[0]["Check_ID"] == "BR-18"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br18_stale_evaluations_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_model_evaluations
+
+        from datetime import datetime, timezone, timedelta
+
+        stale_time = datetime.now(timezone.utc) - timedelta(days=60)
+
+        bedrock_client = MagicMock()
+        bedrock_client.list_evaluation_jobs.return_value = {
+            "jobSummaries": [
+                {
+                    "jobName": "eval-job-old",
+                    "status": "Completed",
+                    "creationTime": stale_time,
+                }
+            ]
+        }
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-18"
+        assert findings[0]["Severity"] == "Medium"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br18_unknown_operation_returns_na(self, mock_client):
+        check = bedrock_app.check_bedrock_model_evaluations
+
+        bedrock_client = MagicMock()
+        bedrock_client.list_evaluation_jobs.side_effect = ClientError(
+            {"Error": {"Code": "UnknownOperation", "Message": "Unknown operation"}},
+            "ListEvaluationJobs",
+        )
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-18"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br18_access_denied_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_model_evaluations
+
+        bedrock_client = MagicMock()
+        bedrock_client.list_evaluation_jobs.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException"}}, "ListEvaluationJobs"
+        )
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-18"
+
+    def test_br18_schema_valid(self):
+        check = bedrock_app.check_bedrock_model_evaluations
+        with patch("bedrock_app.boto3.client") as mock_client:
+            bedrock_client = MagicMock()
+            bedrock_client.list_evaluation_jobs.return_value = {"jobSummaries": []}
+            mock_client.return_value = bedrock_client
+            result = check(region="us-east-1")
+
+        for f in extract_csv_data(result):
+            assert_finding_schema(f)
+
+
+# ===================================================================
+# BR-19: check_bedrock_prompt_flow_validation
+# ===================================================================
+class TestBR19PromptFlowValidation:
+    """BR-19: Verify prompt flows are validated using GetFlow validations."""
+
+    @patch("bedrock_app.boto3.client")
+    def test_br19_no_flows_returns_na(self, mock_client):
+        check = bedrock_app.check_bedrock_prompt_flow_validation
+        agent_client = MagicMock()
+        agent_client.list_flows.return_value = {"flowSummaries": []}
+        mock_client.return_value = agent_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-19"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br19_prepared_flow_no_errors_returns_passed(self, mock_client):
+        check = bedrock_app.check_bedrock_prompt_flow_validation
+        agent_client = MagicMock()
+        agent_client.list_flows.return_value = {
+            "flowSummaries": [{"id": "f1", "name": "GoodFlow", "status": "Prepared"}]
+        }
+        agent_client.get_flow.return_value = {"validations": []}
+        mock_client.return_value = agent_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        passed = [f for f in findings if f["Status"] == "Passed"]
+        assert len(passed) >= 1
+        assert passed[0]["Check_ID"] == "BR-19"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br19_flow_with_error_validation_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_prompt_flow_validation
+        agent_client = MagicMock()
+        agent_client.list_flows.return_value = {
+            "flowSummaries": [{"id": "f1", "name": "BadFlow", "status": "Prepared"}]
+        }
+        agent_client.get_flow.return_value = {
+            "validations": [{"severity": "ERROR", "message": "Node X is not connected"}]
+        }
+        mock_client.return_value = agent_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-19"
+        assert "Node X is not connected" in findings[0]["Finding_Details"]
+
+    @patch("bedrock_app.boto3.client")
+    def test_br19_unprepared_flow_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_prompt_flow_validation
+        agent_client = MagicMock()
+        agent_client.list_flows.return_value = {
+            "flowSummaries": [
+                {"id": "f1", "name": "DraftFlow", "status": "NotPrepared"}
+            ]
+        }
+        agent_client.get_flow.return_value = {"validations": []}
+        mock_client.return_value = agent_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-19"
+
+    def test_br19_schema_valid(self):
+        check = bedrock_app.check_bedrock_prompt_flow_validation
+        with patch("bedrock_app.boto3.client") as mock_client:
+            agent_client = MagicMock()
+            agent_client.list_flows.return_value = {"flowSummaries": []}
+            mock_client.return_value = agent_client
+            result = check(region="us-east-1")
+
+        for f in extract_csv_data(result):
+            assert_finding_schema(f)
+
+
+# ===================================================================
+# BR-20: check_bedrock_knowledge_base_kms_encryption
+# ===================================================================
+class TestBR20KnowledgeBaseKMS:
+    """BR-20: Verify managed KB customer-managed KMS encryption."""
+
+    @patch("bedrock_app.boto3.client")
+    def test_br20_no_kbs_returns_na(self, mock_client):
+        check = bedrock_app.check_bedrock_knowledge_base_kms_encryption
+        agent_client = MagicMock()
+        agent_client.list_knowledge_bases.return_value = {"knowledgeBaseSummaries": []}
+        mock_client.return_value = agent_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-20"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br20_managed_kb_with_cmk_returns_passed(self, mock_client):
+        check = bedrock_app.check_bedrock_knowledge_base_kms_encryption
+        agent_client = MagicMock()
+        agent_client.list_knowledge_bases.return_value = {
+            "knowledgeBaseSummaries": [{"knowledgeBaseId": "kb1", "name": "ManagedKB"}]
+        }
+        agent_client.get_knowledge_base.return_value = {
+            "knowledgeBase": {
+                "knowledgeBaseConfiguration": {
+                    "type": "MANAGED",
+                    "managedKnowledgeBaseConfiguration": {
+                        "serverSideEncryptionConfiguration": {
+                            "kmsKeyArn": "arn:aws:kms:us-east-1:123:key/abc"
+                        }
+                    },
+                }
+            }
+        }
+        mock_client.return_value = agent_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        passed = [f for f in findings if f["Status"] == "Passed"]
+        assert len(passed) >= 1
+        assert passed[0]["Check_ID"] == "BR-20"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br20_managed_kb_without_cmk_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_knowledge_base_kms_encryption
+        agent_client = MagicMock()
+        agent_client.list_knowledge_bases.return_value = {
+            "knowledgeBaseSummaries": [{"knowledgeBaseId": "kb1", "name": "ManagedKB"}]
+        }
+        agent_client.get_knowledge_base.return_value = {
+            "knowledgeBase": {
+                "knowledgeBaseConfiguration": {
+                    "type": "MANAGED",
+                    "managedKnowledgeBaseConfiguration": {},
+                }
+            }
+        }
+        mock_client.return_value = agent_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-20"
+        assert findings[0]["Severity"] == "High"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br20_managed_kb_sdk_gap_returns_na(self, mock_client):
+        # A MANAGED knowledge base whose managedKnowledgeBaseConfiguration block is
+        # absent (bundled botocore predates the field, < 1.43.32) must surface as
+        # N/A "indeterminate", not a false-positive Failed.
+        check = bedrock_app.check_bedrock_knowledge_base_kms_encryption
+        agent_client = MagicMock()
+        agent_client.list_knowledge_bases.return_value = {
+            "knowledgeBaseSummaries": [{"knowledgeBaseId": "kb1", "name": "ManagedKB"}]
+        }
+        agent_client.get_knowledge_base.return_value = {
+            "knowledgeBase": {"knowledgeBaseConfiguration": {"type": "MANAGED"}}
+        }
+        mock_client.return_value = agent_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        na = [f for f in findings if f["Status"] == "N/A"]
+        assert len(na) >= 1
+        assert na[0]["Check_ID"] == "BR-20"
+        assert "1.43.32" in na[0]["Finding_Details"]
+        # Must NOT be reported as a failure on incomplete data.
+        assert all(f["Status"] != "Failed" for f in findings)
+
+    @patch("bedrock_app.boto3.client")
+    def test_br20_custom_vector_store_returns_na_review(self, mock_client):
+        # Custom vector stores (no managed config) cannot be validated from the
+        # KB API; they are flagged for manual review, not failed.
+        check = bedrock_app.check_bedrock_knowledge_base_kms_encryption
+        agent_client = MagicMock()
+        agent_client.list_knowledge_bases.return_value = {
+            "knowledgeBaseSummaries": [{"knowledgeBaseId": "kb1", "name": "VectorKB"}]
+        }
+        agent_client.get_knowledge_base.return_value = {
+            "knowledgeBase": {
+                "knowledgeBaseConfiguration": {
+                    "type": "VECTOR",
+                    "vectorKnowledgeBaseConfiguration": {},
+                },
+                "storageConfiguration": {"type": "OPENSEARCH_SERVERLESS"},
+            }
+        }
+        mock_client.return_value = agent_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        na = [f for f in findings if f["Status"] == "N/A"]
+        assert len(na) >= 1
+        assert na[0]["Check_ID"] == "BR-20"
+        assert "storage layer" in na[0]["Finding_Details"]
+
+    def test_br20_schema_valid(self):
+        check = bedrock_app.check_bedrock_knowledge_base_kms_encryption
+        with patch("bedrock_app.boto3.client") as mock_client:
+            agent_client = MagicMock()
+            agent_client.list_knowledge_bases.return_value = {
+                "knowledgeBaseSummaries": []
+            }
+            mock_client.return_value = agent_client
+            result = check(region="us-east-1")
+
+        for f in extract_csv_data(result):
+            assert_finding_schema(f)
+
+
+# ===================================================================
+# BR-21: check_bedrock_agent_action_group_iam
+# ===================================================================
+class TestBR21AgentActionGroupIAM:
+    """BR-21: Verify action-group Lambda roles follow least privilege."""
+
+    @staticmethod
+    def _agent_client_with_lambda_role(role_name):
+        agent_client = MagicMock()
+        agent_client.list_agents.return_value = {
+            "agentSummaries": [{"agentId": "a1", "agentName": "TestAgent"}]
+        }
+        agent_client.list_agent_action_groups.return_value = {
+            "actionGroupSummaries": [
+                {"actionGroupId": "ag1", "actionGroupName": "ActionGroup1"}
+            ]
+        }
+        agent_client.get_agent_action_group.return_value = {
+            "agentActionGroup": {
+                "actionGroupExecutor": {
+                    "lambda": "arn:aws:lambda:us-east-1:123:function:my-func"
+                }
+            }
+        }
+        lambda_client = MagicMock()
+        lambda_client.get_function.return_value = {
+            "Configuration": {"Role": f"arn:aws:iam::123456789012:role/{role_name}"}
+        }
+        return agent_client, lambda_client
+
+    @patch("bedrock_app.boto3.client")
+    def test_br21_no_agents_returns_na(self, mock_client):
+        check = bedrock_app.check_bedrock_agent_action_group_iam
+        agent_client = MagicMock()
+        agent_client.list_agents.return_value = {"agentSummaries": []}
+        mock_client.return_value = agent_client
+
+        result = check(region="us-east-1", permission_cache={"role_permissions": {}})
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-21"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br21_admin_access_role_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_agent_action_group_iam
+        agent_client, lambda_client = self._agent_client_with_lambda_role("AdminRole")
+
+        def factory(service, **kwargs):
+            return lambda_client if service == "lambda" else agent_client
+
+        mock_client.side_effect = factory
+
+        cache = {
+            "role_permissions": {
+                "AdminRole": {
+                    "attached_policies": [{"name": "AdministratorAccess"}],
+                    "inline_policies": [],
+                }
+            }
+        }
+        result = check(region="us-east-1", permission_cache=cache)
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-21"
+        assert "AdministratorAccess" in findings[0]["Finding_Details"]
+
+    @patch("bedrock_app.boto3.client")
+    def test_br21_wildcard_inline_policy_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_agent_action_group_iam
+        agent_client, lambda_client = self._agent_client_with_lambda_role("WildRole")
+
+        def factory(service, **kwargs):
+            return lambda_client if service == "lambda" else agent_client
+
+        mock_client.side_effect = factory
+
+        cache = {
+            "role_permissions": {
+                "WildRole": {
+                    "attached_policies": [],
+                    "inline_policies": [
+                        {
+                            "name": "inline-wild",
+                            "document": {
+                                "Version": "2012-10-17",
+                                "Statement": [
+                                    {
+                                        "Effect": "Allow",
+                                        "Action": "*",
+                                        "Resource": "*",
+                                    }
+                                ],
+                            },
+                        }
+                    ],
+                }
+            }
+        }
+        result = check(region="us-east-1", permission_cache=cache)
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-21"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br21_scoped_role_returns_passed(self, mock_client):
+        check = bedrock_app.check_bedrock_agent_action_group_iam
+        agent_client, lambda_client = self._agent_client_with_lambda_role("ScopedRole")
+
+        def factory(service, **kwargs):
+            return lambda_client if service == "lambda" else agent_client
+
+        mock_client.side_effect = factory
+
+        cache = {
+            "role_permissions": {
+                "ScopedRole": {
+                    "attached_policies": [{"name": "CustomScopedPolicy"}],
+                    "inline_policies": [],
+                }
+            }
+        }
+        result = check(region="us-east-1", permission_cache=cache)
+        findings = extract_csv_data(result)
+        passed = [f for f in findings if f["Status"] == "Passed"]
+        assert len(passed) >= 1
+        assert passed[0]["Check_ID"] == "BR-21"
+
+    def test_br21_schema_valid(self):
+        check = bedrock_app.check_bedrock_agent_action_group_iam
+        with patch("bedrock_app.boto3.client") as mock_client:
+            agent_client = MagicMock()
+            agent_client.list_agents.return_value = {"agentSummaries": []}
+            mock_client.return_value = agent_client
+            result = check(
+                region="us-east-1", permission_cache={"role_permissions": {}}
+            )
+
+        for f in extract_csv_data(result):
+            assert_finding_schema(f)
+
+
+# ===================================================================
+# BR-23: check_bedrock_guardrail_content_filters
+# ===================================================================
+class TestBR23ContentFilters:
+    """BR-23: Verify all content filters are enabled via contentPolicy.filters."""
+
+    @staticmethod
+    def _filters(types):
+        return [
+            {"type": t, "inputStrength": "HIGH", "outputStrength": "HIGH"}
+            for t in types
+        ]
+
+    @patch("bedrock_app.boto3.client")
+    def test_br23_no_guardrails_returns_na(self, mock_client):
+        check = bedrock_app.check_bedrock_guardrail_content_filters
+        bedrock_client = MagicMock()
+        bedrock_client.list_guardrails.return_value = {"guardrails": []}
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-23"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br23_all_filters_returns_passed(self, mock_client):
+        check = bedrock_app.check_bedrock_guardrail_content_filters
+        bedrock_client = MagicMock()
+        bedrock_client.list_guardrails.return_value = {
+            "guardrails": [{"id": "gr1", "name": "FullGuardrail"}]
+        }
+        bedrock_client.get_guardrail.return_value = {
+            "guardrail": {
+                "contentPolicy": {
+                    "filters": self._filters(["HATE", "INSULTS", "SEXUAL", "VIOLENCE"])
+                }
+            }
+        }
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        passed = [f for f in findings if f["Status"] == "Passed"]
+        assert len(passed) >= 1
+        assert passed[0]["Check_ID"] == "BR-23"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br23_missing_filters_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_guardrail_content_filters
+        bedrock_client = MagicMock()
+        bedrock_client.list_guardrails.return_value = {
+            "guardrails": [{"id": "gr1", "name": "PartialGuardrail"}]
+        }
+        bedrock_client.get_guardrail.return_value = {
+            "guardrail": {
+                "contentPolicy": {"filters": self._filters(["HATE", "VIOLENCE"])}
+            }
+        }
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-23"
+        assert "INSULTS" in findings[0]["Finding_Details"]
+
+    def test_br23_schema_valid(self):
+        check = bedrock_app.check_bedrock_guardrail_content_filters
+        with patch("bedrock_app.boto3.client") as mock_client:
+            bedrock_client = MagicMock()
+            bedrock_client.list_guardrails.return_value = {"guardrails": []}
+            mock_client.return_value = bedrock_client
+            result = check(region="us-east-1")
+
+        for f in extract_csv_data(result):
+            assert_finding_schema(f)
+
+
+# ===================================================================
+# BR-24: check_bedrock_automated_reasoning_policy
+# ===================================================================
+class TestBR24AutomatedReasoning:
+    """BR-24: Verify Automated Reasoning policies via automatedReasoningPolicy."""
+
+    @patch("bedrock_app.boto3.client")
+    def test_br24_no_guardrails_returns_na(self, mock_client):
+        check = bedrock_app.check_bedrock_automated_reasoning_policy
+        bedrock_client = MagicMock()
+        bedrock_client.list_guardrails.return_value = {"guardrails": []}
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-24"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br24_with_ar_policy_returns_passed(self, mock_client):
+        check = bedrock_app.check_bedrock_automated_reasoning_policy
+        bedrock_client = MagicMock()
+        bedrock_client.list_guardrails.return_value = {
+            "guardrails": [{"id": "gr1", "name": "VerifiedGuardrail"}]
+        }
+        bedrock_client.get_guardrail.return_value = {
+            "guardrail": {
+                "automatedReasoningPolicy": {
+                    "policies": [
+                        "arn:aws:bedrock:us-east-1:123:automated-reasoning-policy/p1"
+                    ]
+                }
+            }
+        }
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        passed = [f for f in findings if f["Status"] == "Passed"]
+        assert len(passed) >= 1
+        assert passed[0]["Check_ID"] == "BR-24"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br24_without_ar_policy_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_automated_reasoning_policy
+        bedrock_client = MagicMock()
+        bedrock_client.list_guardrails.return_value = {
+            "guardrails": [{"id": "gr1", "name": "PlainGuardrail"}]
+        }
+        bedrock_client.get_guardrail.return_value = {"guardrail": {}}
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-24"
+
+    def test_br24_schema_valid(self):
+        check = bedrock_app.check_bedrock_automated_reasoning_policy
+        with patch("bedrock_app.boto3.client") as mock_client:
+            bedrock_client = MagicMock()
+            bedrock_client.list_guardrails.return_value = {"guardrails": []}
+            mock_client.return_value = bedrock_client
+            result = check(region="us-east-1")
+
+        for f in extract_csv_data(result):
+            assert_finding_schema(f)
+
+
+# ===================================================================
+# BR-26: check_bedrock_guardrail_pii_filters
+# ===================================================================
+class TestBR26GuardrailPIIFilters:
+    """BR-26: Verify guardrails configure sensitive-information (PII) filters."""
+
+    @patch("bedrock_app.boto3.client")
+    def test_br26_no_guardrails_returns_na(self, mock_client):
+        check = bedrock_app.check_bedrock_guardrail_pii_filters
+        bedrock_client = MagicMock()
+        bedrock_client.list_guardrails.return_value = {"guardrails": []}
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-26"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br26_pii_configured_returns_passed(self, mock_client):
+        check = bedrock_app.check_bedrock_guardrail_pii_filters
+        bedrock_client = MagicMock()
+        bedrock_client.list_guardrails.return_value = {
+            "guardrails": [{"id": "gr1", "name": "PiiGuardrail"}]
+        }
+        bedrock_client.get_guardrail.return_value = {
+            "guardrail": {
+                "sensitiveInformationPolicy": {
+                    "piiEntities": [{"type": "EMAIL", "action": "ANONYMIZE"}],
+                    "regexes": [],
+                }
+            }
+        }
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        passed = [f for f in findings if f["Status"] == "Passed"]
+        assert len(passed) >= 1
+        assert passed[0]["Check_ID"] == "BR-26"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br26_no_pii_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_guardrail_pii_filters
+        bedrock_client = MagicMock()
+        bedrock_client.list_guardrails.return_value = {
+            "guardrails": [{"id": "gr1", "name": "PlainGuardrail"}]
+        }
+        bedrock_client.get_guardrail.return_value = {
+            "guardrail": {
+                "sensitiveInformationPolicy": {"piiEntities": [], "regexes": []}
+            }
+        }
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-26"
+        assert findings[0]["Severity"] == "High"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br26_access_denied_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_guardrail_pii_filters
+        bedrock_client = MagicMock()
+        bedrock_client.list_guardrails.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException"}}, "ListGuardrails"
+        )
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-26"
+
+    def test_br26_schema_valid(self):
+        check = bedrock_app.check_bedrock_guardrail_pii_filters
+        with patch("bedrock_app.boto3.client") as mock_client:
+            bedrock_client = MagicMock()
+            bedrock_client.list_guardrails.return_value = {"guardrails": []}
+            mock_client.return_value = bedrock_client
+            result = check(region="us-east-1")
+
+        for f in extract_csv_data(result):
+            assert_finding_schema(f)
+
+
+# ===================================================================
+# BR-27: check_bedrock_guardrail_contextual_grounding
+# ===================================================================
+class TestBR27ContextualGrounding:
+    """BR-27: Verify guardrails enable contextual grounding checks."""
+
+    @patch("bedrock_app.boto3.client")
+    def test_br27_no_guardrails_returns_na(self, mock_client):
+        check = bedrock_app.check_bedrock_guardrail_contextual_grounding
+        bedrock_client = MagicMock()
+        bedrock_client.list_guardrails.return_value = {"guardrails": []}
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-27"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br27_grounding_enabled_returns_passed(self, mock_client):
+        check = bedrock_app.check_bedrock_guardrail_contextual_grounding
+        bedrock_client = MagicMock()
+        bedrock_client.list_guardrails.return_value = {
+            "guardrails": [{"id": "gr1", "name": "GroundedGuardrail"}]
+        }
+        bedrock_client.get_guardrail.return_value = {
+            "guardrail": {
+                "contextualGroundingPolicy": {
+                    "filters": [
+                        {"type": "GROUNDING", "threshold": 0.75, "enabled": True}
+                    ]
+                }
+            }
+        }
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        passed = [f for f in findings if f["Status"] == "Passed"]
+        assert len(passed) >= 1
+        assert passed[0]["Check_ID"] == "BR-27"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br27_no_grounding_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_guardrail_contextual_grounding
+        bedrock_client = MagicMock()
+        bedrock_client.list_guardrails.return_value = {
+            "guardrails": [{"id": "gr1", "name": "PlainGuardrail"}]
+        }
+        bedrock_client.get_guardrail.return_value = {
+            "guardrail": {"contextualGroundingPolicy": {"filters": []}}
+        }
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-27"
+
+    def test_br27_schema_valid(self):
+        check = bedrock_app.check_bedrock_guardrail_contextual_grounding
+        with patch("bedrock_app.boto3.client") as mock_client:
+            bedrock_client = MagicMock()
+            bedrock_client.list_guardrails.return_value = {"guardrails": []}
+            mock_client.return_value = bedrock_client
+            result = check(region="us-east-1")
+
+        for f in extract_csv_data(result):
+            assert_finding_schema(f)
+
+
+# ===================================================================
+# BR-28: check_bedrock_agent_guardrail_association
+# ===================================================================
+class TestBR28AgentGuardrailAssociation:
+    """BR-28: Verify agents have an associated guardrail."""
+
+    @staticmethod
+    def _agent_client(summaries):
+        agent_client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{"agentSummaries": summaries}]
+        agent_client.get_paginator.return_value = paginator
+        return agent_client
+
+    @patch("bedrock_app.boto3.client")
+    def test_br28_no_agents_returns_na(self, mock_client):
+        check = bedrock_app.check_bedrock_agent_guardrail_association
+        mock_client.return_value = self._agent_client([])
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-28"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br28_agent_with_guardrail_returns_passed(self, mock_client):
+        check = bedrock_app.check_bedrock_agent_guardrail_association
+        mock_client.return_value = self._agent_client(
+            [
+                {
+                    "agentId": "a1",
+                    "agentName": "SafeAgent",
+                    "guardrailConfiguration": {
+                        "guardrailIdentifier": "gr-1",
+                        "guardrailVersion": "1",
+                    },
+                }
+            ]
+        )
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        passed = [f for f in findings if f["Status"] == "Passed"]
+        assert len(passed) >= 1
+        assert passed[0]["Check_ID"] == "BR-28"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br28_agent_without_guardrail_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_agent_guardrail_association
+        mock_client.return_value = self._agent_client(
+            [{"agentId": "a1", "agentName": "OpenAgent"}]
+        )
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-28"
+        assert findings[0]["Severity"] == "High"
+
+    def test_br28_schema_valid(self):
+        check = bedrock_app.check_bedrock_agent_guardrail_association
+        with patch("bedrock_app.boto3.client") as mock_client:
+            mock_client.return_value = self._agent_client([])
+            result = check(region="us-east-1")
+
+        for f in extract_csv_data(result):
+            assert_finding_schema(f)
+
+
+# ===================================================================
+# BR-29: check_bedrock_agent_idle_session_ttl
+# ===================================================================
+class TestBR29AgentIdleSessionTTL:
+    """BR-29: Verify agent idle session TTL is within the recommended bound."""
+
+    @staticmethod
+    def _agent_client(summaries, get_agent_return=None):
+        agent_client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{"agentSummaries": summaries}]
+        agent_client.get_paginator.return_value = paginator
+        if get_agent_return is not None:
+            agent_client.get_agent.return_value = get_agent_return
+        return agent_client
+
+    @patch("bedrock_app.boto3.client")
+    def test_br29_no_agents_returns_na(self, mock_client):
+        check = bedrock_app.check_bedrock_agent_idle_session_ttl
+        mock_client.return_value = self._agent_client([])
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-29"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br29_short_ttl_returns_passed(self, mock_client):
+        check = bedrock_app.check_bedrock_agent_idle_session_ttl
+        mock_client.return_value = self._agent_client(
+            [{"agentId": "a1", "agentName": "ShortAgent"}],
+            {"agent": {"idleSessionTTLInSeconds": 600}},
+        )
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        passed = [f for f in findings if f["Status"] == "Passed"]
+        assert len(passed) >= 1
+        assert passed[0]["Check_ID"] == "BR-29"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br29_long_ttl_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_agent_idle_session_ttl
+        mock_client.return_value = self._agent_client(
+            [{"agentId": "a1", "agentName": "LongAgent"}],
+            {"agent": {"idleSessionTTLInSeconds": 7200}},
+        )
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-29"
+
+    def test_br29_schema_valid(self):
+        check = bedrock_app.check_bedrock_agent_idle_session_ttl
+        with patch("bedrock_app.boto3.client") as mock_client:
+            mock_client.return_value = self._agent_client([])
+            result = check(region="us-east-1")
+
+        for f in extract_csv_data(result):
+            assert_finding_schema(f)
+
+
+# ===================================================================
+# BR-30: check_bedrock_imported_model_kms_encryption
+# ===================================================================
+class TestBR30ImportedModelKMS:
+    """BR-30: Verify imported models use customer-managed KMS keys."""
+
+    @staticmethod
+    def _bedrock_client(summaries, get_return=None, list_side_effect=None):
+        bedrock_client = MagicMock()
+        paginator = MagicMock()
+        if list_side_effect is not None:
+            paginator.paginate.side_effect = list_side_effect
+        else:
+            paginator.paginate.return_value = [{"modelSummaries": summaries}]
+        bedrock_client.get_paginator.return_value = paginator
+        if get_return is not None:
+            bedrock_client.get_imported_model.return_value = get_return
+        return bedrock_client
+
+    @patch("bedrock_app.boto3.client")
+    def test_br30_no_models_returns_na(self, mock_client):
+        check = bedrock_app.check_bedrock_imported_model_kms_encryption
+        mock_client.return_value = self._bedrock_client([])
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-30"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br30_customer_key_returns_passed(self, mock_client):
+        check = bedrock_app.check_bedrock_imported_model_kms_encryption
+        mock_client.return_value = self._bedrock_client(
+            [{"modelArn": "arn:model:1", "modelName": "imported-1"}],
+            {"modelKmsKeyArn": "arn:aws:kms:us-east-1:123:key/abc"},
+        )
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        passed = [f for f in findings if f["Status"] == "Passed"]
+        assert len(passed) >= 1
+        assert passed[0]["Check_ID"] == "BR-30"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br30_aws_owned_key_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_imported_model_kms_encryption
+        mock_client.return_value = self._bedrock_client(
+            [{"modelArn": "arn:model:1", "modelName": "imported-1"}],
+            {},
+        )
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-30"
+        assert findings[0]["Severity"] == "High"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br30_access_denied_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_imported_model_kms_encryption
+        mock_client.return_value = self._bedrock_client(
+            [],
+            list_side_effect=ClientError(
+                {"Error": {"Code": "AccessDeniedException"}}, "ListImportedModels"
+            ),
+        )
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-30"
+
+    def test_br30_schema_valid(self):
+        check = bedrock_app.check_bedrock_imported_model_kms_encryption
+        with patch("bedrock_app.boto3.client") as mock_client:
+            mock_client.return_value = self._bedrock_client([])
+            result = check(region="us-east-1")
+
+        for f in extract_csv_data(result):
+            assert_finding_schema(f)
+
+
+# ===================================================================
+# BR-31: check_bedrock_batch_inference_output_encryption
+# ===================================================================
+class TestBR31BatchInferenceOutputEncryption:
+    """BR-31: Verify batch inference jobs encrypt output with customer KMS."""
+
+    @staticmethod
+    def _bedrock_client(summaries, list_side_effect=None):
+        bedrock_client = MagicMock()
+        paginator = MagicMock()
+        if list_side_effect is not None:
+            paginator.paginate.side_effect = list_side_effect
+        else:
+            paginator.paginate.return_value = [{"invocationJobSummaries": summaries}]
+        bedrock_client.get_paginator.return_value = paginator
+        return bedrock_client
+
+    @patch("bedrock_app.boto3.client")
+    def test_br31_no_jobs_returns_na(self, mock_client):
+        check = bedrock_app.check_bedrock_batch_inference_output_encryption
+        mock_client.return_value = self._bedrock_client([])
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-31"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br31_job_with_cmk_returns_passed(self, mock_client):
+        check = bedrock_app.check_bedrock_batch_inference_output_encryption
+        mock_client.return_value = self._bedrock_client(
+            [
+                {
+                    "jobName": "batch-1",
+                    "outputDataConfig": {
+                        "s3OutputDataConfig": {
+                            "s3Uri": "s3://out/",
+                            "s3EncryptionKeyId": "arn:aws:kms:us-east-1:123:key/abc",
+                        }
+                    },
+                }
+            ]
+        )
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        passed = [f for f in findings if f["Status"] == "Passed"]
+        assert len(passed) >= 1
+        assert passed[0]["Check_ID"] == "BR-31"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br31_job_without_cmk_returns_failed(self, mock_client):
+        check = bedrock_app.check_bedrock_batch_inference_output_encryption
+        mock_client.return_value = self._bedrock_client(
+            [
+                {
+                    "jobName": "batch-1",
+                    "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://out/"}},
+                }
+            ]
+        )
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-31"
+        assert findings[0]["Severity"] == "Medium"
+
+    def test_br31_schema_valid(self):
+        check = bedrock_app.check_bedrock_batch_inference_output_encryption
+        with patch("bedrock_app.boto3.client") as mock_client:
+            mock_client.return_value = self._bedrock_client([])
+            result = check(region="us-east-1")
+
+        for f in extract_csv_data(result):
+            assert_finding_schema(f)
+
+
+# ===================================================================
+# BR-32: check_bedrock_cloudwatch_alarms
+# ===================================================================
+class TestBR32CloudWatchAlarms:
+    """BR-32: Verify CloudWatch alarms exist on AWS/Bedrock metrics."""
+
+    @patch("bedrock_app.detect_bedrock_regional_footprint", return_value=False)
+    @patch("bedrock_app.boto3.client")
+    def test_br32_no_footprint_returns_na(self, mock_client, mock_footprint):
+        check = bedrock_app.check_bedrock_cloudwatch_alarms
+        result = check(region="eu-west-3")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-32"
+
+    @patch("bedrock_app.detect_bedrock_regional_footprint", return_value=True)
+    @patch("bedrock_app.boto3.client")
+    def test_br32_bedrock_alarm_returns_passed(self, mock_client, mock_footprint):
+        check = bedrock_app.check_bedrock_cloudwatch_alarms
+        cw_client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [
+            {
+                "MetricAlarms": [
+                    {"AlarmName": "bedrock-throttle", "Namespace": "AWS/Bedrock"}
+                ]
+            }
+        ]
+        cw_client.get_paginator.return_value = paginator
+        mock_client.return_value = cw_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "Passed"
+        assert findings[0]["Check_ID"] == "BR-32"
+
+    @patch("bedrock_app.detect_bedrock_regional_footprint", return_value=True)
+    @patch("bedrock_app.boto3.client")
+    def test_br32_metric_math_alarm_returns_passed(self, mock_client, mock_footprint):
+        check = bedrock_app.check_bedrock_cloudwatch_alarms
+        cw_client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [
+            {
+                "MetricAlarms": [
+                    {
+                        "AlarmName": "bedrock-tpm",
+                        "Metrics": [
+                            {"MetricStat": {"Metric": {"Namespace": "AWS/Bedrock"}}}
+                        ],
+                    }
+                ]
+            }
+        ]
+        cw_client.get_paginator.return_value = paginator
+        mock_client.return_value = cw_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "Passed"
+        assert findings[0]["Check_ID"] == "BR-32"
+
+    @patch("bedrock_app.detect_bedrock_regional_footprint", return_value=True)
+    @patch("bedrock_app.boto3.client")
+    def test_br32_no_bedrock_alarm_returns_failed(self, mock_client, mock_footprint):
+        check = bedrock_app.check_bedrock_cloudwatch_alarms
+        cw_client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [
+            {"MetricAlarms": [{"AlarmName": "ec2-cpu", "Namespace": "AWS/EC2"}]}
+        ]
+        cw_client.get_paginator.return_value = paginator
+        mock_client.return_value = cw_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "Failed"
+        assert findings[0]["Check_ID"] == "BR-32"
+        assert findings[0]["Severity"] == "Medium"
+
+    @patch("bedrock_app.detect_bedrock_regional_footprint", return_value=True)
+    @patch("bedrock_app.boto3.client")
+    def test_br32_schema_valid(self, mock_client, mock_footprint):
+        check = bedrock_app.check_bedrock_cloudwatch_alarms
+        cw_client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{"MetricAlarms": []}]
+        cw_client.get_paginator.return_value = paginator
+        mock_client.return_value = cw_client
+
+        result = check(region="us-east-1")
+        for f in extract_csv_data(result):
+            assert_finding_schema(f)

--- a/tests/test_bedrock_checks.py
+++ b/tests/test_bedrock_checks.py
@@ -2390,7 +2390,9 @@ class TestBR21AgentActionGroupIAM:
         )
         mock_client.return_value = agent_client
 
-        result = check(region="ap-southeast-3", permission_cache={"role_permissions": {}})
+        result = check(
+            region="ap-southeast-3", permission_cache={"role_permissions": {}}
+        )
         findings = extract_csv_data(result)
         assert findings[0]["Status"] == "N/A"
         assert findings[0]["Check_ID"] == "BR-21"

--- a/tests/test_bedrock_checks.py
+++ b/tests/test_bedrock_checks.py
@@ -1932,6 +1932,29 @@ class TestBR18ModelEvaluations:
         assert findings[0]["Status"] == "Failed"
         assert findings[0]["Check_ID"] == "BR-18"
 
+    @patch("bedrock_app.boto3.client")
+    def test_br18_account_not_authorized_returns_na(self, mock_client):
+        # Account/feature-gate denial (model evaluation not enabled) must be N/A.
+        check = bedrock_app.check_bedrock_model_evaluations
+
+        bedrock_client = MagicMock()
+        bedrock_client.list_evaluation_jobs.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "AccessDeniedException",
+                    "Message": "Your account is not authorized to invoke this API operation.",
+                }
+            },
+            "ListEvaluationJobs",
+        )
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-18"
+
     def test_br18_schema_valid(self):
         check = bedrock_app.check_bedrock_model_evaluations
         with patch("bedrock_app.boto3.client") as mock_client:
@@ -2810,6 +2833,29 @@ class TestBR30ImportedModelKMS:
         assert findings[0]["Status"] == "Failed"
         assert findings[0]["Check_ID"] == "BR-30"
 
+    @patch("bedrock_app.boto3.client")
+    def test_br30_account_not_authorized_returns_na(self, mock_client):
+        # Account/feature-gate denial (Custom Model Import not enabled) must be
+        # N/A, not a Failed finding telling the user to grant IAM permissions.
+        check = bedrock_app.check_bedrock_imported_model_kms_encryption
+        mock_client.return_value = self._bedrock_client(
+            [],
+            list_side_effect=ClientError(
+                {
+                    "Error": {
+                        "Code": "AccessDeniedException",
+                        "Message": "Your account is not authorized to invoke this API operation.",
+                    }
+                },
+                "ListImportedModels",
+            ),
+        )
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-30"
+
     def test_br30_schema_valid(self):
         check = bedrock_app.check_bedrock_imported_model_kms_encryption
         with patch("bedrock_app.boto3.client") as mock_client:
@@ -2887,6 +2933,28 @@ class TestBR31BatchInferenceOutputEncryption:
         assert findings[0]["Status"] == "Failed"
         assert findings[0]["Check_ID"] == "BR-31"
         assert findings[0]["Severity"] == "Medium"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br31_account_not_authorized_returns_na(self, mock_client):
+        # Account/feature-gate denial (batch inference not enabled) must be N/A.
+        check = bedrock_app.check_bedrock_batch_inference_output_encryption
+        mock_client.return_value = self._bedrock_client(
+            [],
+            list_side_effect=ClientError(
+                {
+                    "Error": {
+                        "Code": "AccessDeniedException",
+                        "Message": "Your account is not authorized to invoke this API operation.",
+                    }
+                },
+                "ListModelInvocationJobs",
+            ),
+        )
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-31"
 
     def test_br31_schema_valid(self):
         check = bedrock_app.check_bedrock_batch_inference_output_encryption

--- a/tests/test_bedrock_checks.py
+++ b/tests/test_bedrock_checks.py
@@ -746,6 +746,29 @@ class TestBR09KBEncryption:
         assert findings[0]["Severity"] == "Informational"
 
     @patch("boto3.client")
+    def test_br09_region_unsupported_returns_na(self, mock_client):
+        # Knowledge Bases API absent in the region -> N/A, not ERROR/Failed.
+        check = bedrock_app.check_bedrock_knowledge_base_encryption
+        mock_agent = MagicMock()
+        mock_client.return_value = mock_agent
+        paginator = MagicMock()
+        mock_agent.get_paginator.return_value = paginator
+        paginator.paginate.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "UnknownOperationException",
+                    "Message": "Unknown operation ListKnowledgeBases",
+                }
+            },
+            "ListKnowledgeBases",
+        )
+        result = check(region="ap-southeast-3")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-09"
+        assert "not available" in findings[0]["Finding_Details"]
+
+    @patch("boto3.client")
     def test_br09_schema_valid(self, mock_client):
         check = bedrock_app.check_bedrock_knowledge_base_encryption
         mock_agent = MagicMock()
@@ -2168,6 +2191,28 @@ class TestBR20KnowledgeBaseKMS:
         assert na[0]["Check_ID"] == "BR-20"
         assert "storage layer" in na[0]["Finding_Details"]
 
+    @patch("bedrock_app.boto3.client")
+    def test_br20_region_unsupported_returns_na(self, mock_client):
+        # Knowledge Bases API absent in the region -> N/A, not ERROR.
+        check = bedrock_app.check_bedrock_knowledge_base_kms_encryption
+        agent_client = MagicMock()
+        agent_client.list_knowledge_bases.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "UnknownOperationException",
+                    "Message": "Unknown operation ListKnowledgeBases",
+                }
+            },
+            "ListKnowledgeBases",
+        )
+        mock_client.return_value = agent_client
+
+        result = check(region="ap-southeast-3")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-20"
+        assert "not available" in findings[0]["Finding_Details"]
+
     def test_br20_schema_valid(self):
         check = bedrock_app.check_bedrock_knowledge_base_kms_encryption
         with patch("bedrock_app.boto3.client") as mock_client:
@@ -2308,6 +2353,28 @@ class TestBR21AgentActionGroupIAM:
         passed = [f for f in findings if f["Status"] == "Passed"]
         assert len(passed) >= 1
         assert passed[0]["Check_ID"] == "BR-21"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br21_region_unsupported_returns_na(self, mock_client):
+        # Bedrock Agents API absent in the region -> N/A, not ERROR.
+        check = bedrock_app.check_bedrock_agent_action_group_iam
+        agent_client = MagicMock()
+        agent_client.list_agents.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "UnknownOperationException",
+                    "Message": "Unknown operation ListAgents",
+                }
+            },
+            "ListAgents",
+        )
+        mock_client.return_value = agent_client
+
+        result = check(region="ap-southeast-3", permission_cache={"role_permissions": {}})
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-21"
+        assert "not available" in findings[0]["Finding_Details"]
 
     def test_br21_schema_valid(self):
         check = bedrock_app.check_bedrock_agent_action_group_iam
@@ -2465,6 +2532,60 @@ class TestBR24AutomatedReasoning:
             bedrock_client = MagicMock()
             bedrock_client.list_guardrails.return_value = {"guardrails": []}
             mock_client.return_value = bedrock_client
+            result = check(region="us-east-1")
+
+        for f in extract_csv_data(result):
+            assert_finding_schema(f)
+
+
+# ===================================================================
+# BR-25: check_bedrock_rag_evaluation_jobs
+# ===================================================================
+class TestBR25RAGEvaluationJobs:
+    """BR-25: Verify RAG applications have evaluation jobs configured."""
+
+    @patch("bedrock_app.boto3.client")
+    def test_br25_no_kbs_returns_na(self, mock_client):
+        check = bedrock_app.check_bedrock_rag_evaluation_jobs
+        agent_client = MagicMock()
+        agent_client.list_knowledge_bases.return_value = {"knowledgeBaseSummaries": []}
+        mock_client.return_value = agent_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-25"
+
+    @patch("bedrock_app.boto3.client")
+    def test_br25_region_unsupported_returns_na(self, mock_client):
+        # Knowledge Bases / evaluation API absent in the region -> N/A, not ERROR.
+        check = bedrock_app.check_bedrock_rag_evaluation_jobs
+        agent_client = MagicMock()
+        agent_client.list_knowledge_bases.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "UnknownOperationException",
+                    "Message": "Unknown operation ListKnowledgeBases",
+                }
+            },
+            "ListKnowledgeBases",
+        )
+        mock_client.return_value = agent_client
+
+        result = check(region="ap-southeast-3")
+        findings = extract_csv_data(result)
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-25"
+        assert "not available" in findings[0]["Finding_Details"]
+
+    def test_br25_schema_valid(self):
+        check = bedrock_app.check_bedrock_rag_evaluation_jobs
+        with patch("bedrock_app.boto3.client") as mock_client:
+            agent_client = MagicMock()
+            agent_client.list_knowledge_bases.return_value = {
+                "knowledgeBaseSummaries": []
+            }
+            mock_client.return_value = agent_client
             result = check(region="us-east-1")
 
         for f in extract_csv_data(result):

--- a/tests/test_bedrock_checks.py
+++ b/tests/test_bedrock_checks.py
@@ -1853,8 +1853,11 @@ class TestBR17CustomModelKMSEncryption:
 class TestBR18ModelEvaluations:
     """BR-18: Check if model evaluation jobs exist."""
 
+    @patch("bedrock_app.detect_bedrock_regional_footprint", return_value=True)
     @patch("bedrock_app.boto3.client")
-    def test_br18_no_evaluations_returns_failed(self, mock_client):
+    def test_br18_no_evaluations_with_footprint_returns_failed(
+        self, mock_client, mock_footprint
+    ):
         check = bedrock_app.check_bedrock_model_evaluations
 
         bedrock_client = MagicMock()
@@ -1867,6 +1870,23 @@ class TestBR18ModelEvaluations:
         assert findings[0]["Status"] == "Failed"
         assert findings[0]["Check_ID"] == "BR-18"
         assert findings[0]["Severity"] == "Medium"
+
+    @patch("bedrock_app.detect_bedrock_regional_footprint", return_value=False)
+    @patch("bedrock_app.boto3.client")
+    def test_br18_no_evaluations_no_footprint_returns_na(
+        self, mock_client, mock_footprint
+    ):
+        check = bedrock_app.check_bedrock_model_evaluations
+
+        bedrock_client = MagicMock()
+        bedrock_client.list_evaluation_jobs.return_value = {"jobSummaries": []}
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+        assert len(findings) >= 1
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Check_ID"] == "BR-18"
 
     @patch("bedrock_app.boto3.client")
     def test_br18_recent_evaluations_returns_passed(self, mock_client):

--- a/tests/test_core_iam_coverage.py
+++ b/tests/test_core_iam_coverage.py
@@ -16,6 +16,13 @@ _SECTION_CHECKS = [
             "bedrock:GetModelInvocationLoggingConfiguration",
             "bedrock:ListKnowledgeBases",
             "bedrock:GetKnowledgeBase",
+            "bedrock:ListEvaluationJobs",  # BR-18
+            "bedrock:ListImportedModels",  # BR-30
+            "bedrock:GetImportedModel",  # BR-30
+            "bedrock:ListModelInvocationJobs",  # BR-31
+            "servicequotas:ListServiceQuotas",  # BR-22
+            "servicequotas:GetServiceQuota",  # BR-22
+            "cloudwatch:DescribeAlarms",
         },
     },
     {
@@ -34,6 +41,13 @@ _SECTION_CHECKS = [
             "bedrock:GetModelInvocationLoggingConfiguration",
             "bedrock:ListKnowledgeBases",
             "bedrock:GetKnowledgeBase",
+            "bedrock:ListEvaluationJobs",  # BR-18
+            "bedrock:ListImportedModels",  # BR-30
+            "bedrock:GetImportedModel",  # BR-30
+            "bedrock:ListModelInvocationJobs",  # BR-31
+            "servicequotas:ListServiceQuotas",  # BR-22
+            "servicequotas:GetServiceQuota",  # BR-22
+            "cloudwatch:DescribeAlarms",
         },
     },
     {

--- a/tests/test_core_iam_coverage.py
+++ b/tests/test_core_iam_coverage.py
@@ -23,6 +23,8 @@ _SECTION_CHECKS = [
             "servicequotas:ListServiceQuotas",  # BR-22
             "servicequotas:GetServiceQuota",  # BR-22
             "cloudwatch:DescribeAlarms",
+            "organizations:DescribeOrganization",  # BR-15
+            "organizations:ListPolicies",  # BR-15
         },
     },
     {
@@ -48,6 +50,8 @@ _SECTION_CHECKS = [
             "servicequotas:ListServiceQuotas",  # BR-22
             "servicequotas:GetServiceQuota",  # BR-22
             "cloudwatch:DescribeAlarms",
+            "organizations:DescribeOrganization",  # BR-15
+            "organizations:ListPolicies",  # BR-15
         },
     },
     {


### PR DESCRIPTION
## Summary

  This branch expands the Amazon Bedrock assessment to 32 checks (18 new checks, BR-15..32), brings the framework
  total to 134 checks, and fixes accuracy issues so that "resource/feature absent" conditions are reported as
  N/A instead of false failures. It also updates the supporting IAM permissions, dependency pins, CloudFormation
  templates, and documentation.

  ### What's included

  New Bedrock checks (BR-15..32)
  - BR-15..25 — cross-account guardrails enforcement, guardrail tier validation, custom-model KMS encryption, model
  evaluation implementation, prompt flow validation, knowledge base KMS encryption, agent action-group IAM least
  privilege, model-invocation throttling limits, guardrail content-filter coverage, automated reasoning policy, RAG
  evaluation jobs
  - BR-26..32 — guardrail sensitive-information (PII) filters, contextual grounding, agent guardrail association, agent
  idle session TTL, imported-model KMS encryption, batch-inference output encryption, CloudWatch alarms on AWS/Bedrock metrics

  Accuracy / false-failure fixes (validated against AWS API references and the boto3/botocore service models)
  - Region-unsupported APIs reported as N/A for BR-09/20/21/25
  - Account/feature-gate denials reported as N/A for BR-18/30/31
  - BR-18 model-evaluation check now gates the empty-result case on detect_bedrock_regional_footprint: returns N/A when
  no Bedrock resources exist in the region, and only reports Failed when Bedrock is in use but no evaluation jobs are
  configured (previously it failed unconditionally)
  - Field-accuracy fixes verified against AWS docs (e.g. BEDROCK_POLICY org type, contentPolicy.tier.tierName,
  modelKmsKeyArn, GetFlow validations, managed-KB serverSideEncryptionConfiguration.kmsKeyArn)

  _IAM_ — all three CloudFormation templates grant the additional read-only actions the new checks need (Organizations
  describe/list, Service Quotas, cloudwatch:DescribeAlarms, Bedrock action-group / imported-model / invocation-job /
  evaluation-job reads, and lambda:GetFunction).

  _Dependencies_ — pin boto3/botocore to 1.43.32 across Lambda functions and tests (first release modeling
  managedKnowledgeBaseConfiguration); add the dependency to functions that imported it without declaring it, plus a
  missing resolve_regions/requirements.txt.

  _Multi-region_ — BR-26..32 run per scanned region (tagged with the region); BR-15 stays global (runs once on the primary
  region, tagged Global).

### Docs 
— README, SECURITY_CHECKS.md, SECURITY_CHECKS_FINSERV.md, DEVELOPER_GUIDE.md, and TROUBLESHOOTING.md updated to the latest counts: 70 core (32 Bedrock + 25 SageMaker + 13 AgentCore) + 64 FinServ = 134 total.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
