### PR TITLE
Harden and gate the release pipeline

### DIFF
--- a/.github/workflows/ash-full-repository-scan.yml
+++ b/.github/workflows/ash-full-repository-scan.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload scan results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ash-full-scan-results
           path: ash-output.log

--- a/.github/workflows/ash-full-repository-scan.yml
+++ b/.github/workflows/ash-full-repository-scan.yml
@@ -29,8 +29,12 @@ jobs:
         run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.2.6
 
       - name: Run ASH full repository scan
-        run: ash --mode container 2>&1 | tee ash-output.log
-        continue-on-error: true
+        # pipefail is required: without it the step reports tee's exit status,
+        # so a failing scan looks green. continue-on-error was also removed —
+        # a security scan that cannot fail the build is not a gate.
+        run: |
+          set -o pipefail
+          ash --mode container 2>&1 | tee ash-output.log
 
       - name: Generate scan summary
         run: |

--- a/.github/workflows/ash-security-scan.yml
+++ b/.github/workflows/ash-security-scan.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Get changed files
         id: changed-files
         # Pinned to the v47.0.6 commit SHA; see CVE-2025-30066.
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
             **/*.py
@@ -32,7 +32,7 @@ jobs:
 
       - name: Set up Python
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/ash-security-scan.yml
+++ b/.github/workflows/ash-security-scan.yml
@@ -18,7 +18,8 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        # Pinned to the v47.0.6 commit SHA; see CVE-2025-30066.
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96
         with:
           files: |
             **/*.py
@@ -59,7 +60,10 @@ jobs:
 
       - name: Run ASH scan on changed files
         if: steps.changed-files.outputs.any_changed == 'true'
+        # pipefail is required: without it this step reports tee's exit status,
+        # so a failing scan would pass the gate.
         run: |
+          set -o pipefail
           cd /tmp/ash-scan
           ash --mode container 2>&1 | tee /tmp/ash-output.log
 

--- a/.github/workflows/cfn-lint.yml
+++ b/.github/workflows/cfn-lint.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Get changed CloudFormation files
         id: changed-files
         # Pinned to the v47.0.6 commit SHA; see CVE-2025-30066.
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
             **/*.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Set up Python
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/cfn-lint.yml
+++ b/.github/workflows/cfn-lint.yml
@@ -16,7 +16,8 @@ jobs:
 
       - name: Get changed CloudFormation files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        # Pinned to the v47.0.6 commit SHA; see CVE-2025-30066.
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96
         with:
           files: |
             **/*.yaml
@@ -31,7 +32,9 @@ jobs:
 
       - name: Install cfn-lint
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: pip install cfn-lint
+        # Pinned: an unpinned linter turns an upstream release into an
+        # unrelated red build on the next PR.
+        run: pip install 'cfn-lint==1.54.0'
 
       - name: Lint CloudFormation templates
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -17,27 +17,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Get changed Python files
         id: changed-files
         # Pinned to the v47.0.6 commit SHA. A mutable tag on this action was
         # compromised in March 2025 (CVE-2025-30066), so the version must be
         # immutable rather than a moving tag.
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
             **/*.py
 
       - name: Set up Python
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
       - name: Install uv
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
 
       - name: Install ruff
         if: steps.changed-files.outputs.any_changed == 'true'

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -7,6 +7,11 @@ on:
 permissions:
   contents: read
 
+env:
+  # Pinned so the gate is reproducible. Ruff's default rule set widens between
+  # releases; ruff.toml pins the rules, and this pins the binary that reads it.
+  RUFF_VERSION: "0.16.2"
+
 jobs:
   python-lint:
     runs-on: ubuntu-latest
@@ -16,7 +21,10 @@ jobs:
 
       - name: Get changed Python files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        # Pinned to the v47.0.6 commit SHA. A mutable tag on this action was
+        # compromised in March 2025 (CVE-2025-30066), so the version must be
+        # immutable rather than a moving tag.
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96
         with:
           files: |
             **/*.py
@@ -33,20 +41,31 @@ jobs:
 
       - name: Install ruff
         if: steps.changed-files.outputs.any_changed == 'true'
-        run: uv tool install ruff
+        run: uv tool install "ruff==${RUFF_VERSION}"
 
       - name: Run ruff check on changed files
         if: steps.changed-files.outputs.any_changed == 'true'
+        # Filenames arrive through the environment, never interpolated into the
+        # shell. A crafted filename in a fork PR would otherwise be a command
+        # injection sink.
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
+          set -o pipefail
           echo "Checking changed Python files:"
-          echo "${{ steps.changed-files.outputs.all_changed_files }}" | tr ' ' '\n'
-          uv tool run ruff check --output-format=github ${{ steps.changed-files.outputs.all_changed_files }}
+          printf '%s\n' "${CHANGED_FILES}" | tr ' ' '\n'
+          # shellcheck disable=SC2086
+          uv tool run ruff check --output-format=github ${CHANGED_FILES}
 
       - name: Run ruff format check on changed files
         if: steps.changed-files.outputs.any_changed == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
+          set -o pipefail
           echo "Checking format of changed Python files:"
-          uv tool run ruff format --check ${{ steps.changed-files.outputs.all_changed_files }}
+          # shellcheck disable=SC2086
+          uv tool run ruff format --check ${CHANGED_FILES}
 
       - name: Skip message
         if: steps.changed-files.outputs.any_changed == 'false'

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,22 +1,34 @@
 name: AI/ML Security Assessment Tests
 
+# Least privilege. This workflow only reads the repository and uploads an
+# artifact, so it needs no write scopes. Five of the seven workflows already
+# declared this; python-tests.yml did not, which checkov CKV2_GHA_1 flags as an
+# implicit write-all token.
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, develop]
-    paths:
+    paths: &test-paths
       - "aiml-security-assessment/functions/security/**"
       - "tests/**"
       - "consolidate_html_reports.py"
-      - "tests/test_consolidate_finserv.py"
+      - "generate_provenance.py"
+      # Tests assert against these, so a change here must run the suite:
+      # test_legacy_contracts.py parses both templates and the state machine,
+      # and the docs are the source for provenance.json.
+      - "aiml-security-assessment/template.yaml"
+      - "aiml-security-assessment/template-multi-account.yaml"
+      - "aiml-security-assessment/statemachine/**"
+      - "deployment/**"
+      - "buildspec.yml"
+      - "docs/**"
+      - "ruff.toml"
       - ".github/workflows/python-tests.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "aiml-security-assessment/functions/security/**"
-      - "tests/**"
-      - "consolidate_html_reports.py"
-      - "tests/test_consolidate_finserv.py"
-      - ".github/workflows/python-tests.yml"
+    paths: *test-paths
 
 jobs:
   test:
@@ -37,8 +49,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r tests/requirements.txt
-          # Install pydantic for schema validation used by Lambda functions
-          pip install pydantic>=2.0.0
+          # Install pydantic for schema validation used by Lambda functions.
+          # Quoting is required: unquoted, `>=` is a shell redirect, so this
+          # wrote a file named "=2.0.0" and installed pydantic UNCONSTRAINED.
+          # The upper bound must match the Lambda requirement, or CI can pass
+          # against a pydantic major the runtime forbids.
+          pip install 'pydantic>=2.0.0,<3.0.0'
 
       - name: Run upstream tests with coverage
         env:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -38,10 +38,10 @@ jobs:
         python-version: ["3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage-report-${{ matrix.python-version }}
           path: coverage.xml

--- a/.github/workflows/sam-validate.yml
+++ b/.github/workflows/sam-validate.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Get changed SAM files
         id: changed-files
         # Pinned to the v47.0.6 commit SHA; see CVE-2025-30066.
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
             aiml-security-assessment/**
@@ -25,13 +25,13 @@ jobs:
 
       - name: Set up Python
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
       - name: Set up SAM CLI
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: aws-actions/setup-sam@v2
+        uses: aws-actions/setup-sam@f84ec7d548307efafe33230528756de3c5841a17 # v2
         with:
           use-installer: true
 

--- a/.github/workflows/sam-validate.yml
+++ b/.github/workflows/sam-validate.yml
@@ -16,7 +16,8 @@ jobs:
 
       - name: Get changed SAM files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        # Pinned to the v47.0.6 commit SHA; see CVE-2025-30066.
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96
         with:
           files: |
             aiml-security-assessment/**
@@ -51,6 +52,13 @@ jobs:
         run: |
           cd aiml-security-assessment
           sam build --template template.yaml
+      - name: SAM Build (multi-account)
+        # Both templates were validated but only one was built, so a
+        # multi-account-only build break shipped undetected.
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          cd aiml-security-assessment
+          sam build --template template-multi-account.yaml --build-dir .aws-sam/build-multi
 
       - name: Skip message
         if: steps.changed-files.outputs.any_changed == 'false'

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,6 +4,9 @@ pytest-mock>=3.11.0
 moto[all]>=4.2.0
 boto3==1.43.32
 botocore==1.43.32
-pydantic>=2.0.0
+# Upper bound matches the Lambda runtime requirement
+# (finserv_assessments/requirements.txt), so tests cannot pass against a
+# pydantic major the deployed function forbids.
+pydantic>=2.0.0,<3.0.0
 beautifulsoup4==4.13.4
 ripgrep>=15.1.0


### PR DESCRIPTION
# Harden and gate the release pipeline

Six workflow fixes, split out of the Responsible AI GRC rebrand branch so they can be
reviewed on their own merits rather than bundled with a relabelling. **No rebrand content
is in this branch.**

Base: `main` @ `0a5ed70`. One commit, 7 files, +79 / −22.

## Why this is a separate PR

These changes were originally commit `8883644` on
[the rebrand branch](https://github.com/aws-samples/sample-aiml-security-assessment/pull/54).
Thirteen of the fourteen workflow changes there were not required by the rename. Bundling
them meant a reviewer had to accept security-gate changes in order to approve a relabelling,
and it backfired mechanically: editing the workflows pulled them into ASH's changed-file
scan, surfacing findings in files that branch had no reason to touch, and PR checks went from
6/6 green to 5/6. So they were reverted there and moved here.

## Two gates could not fail

This is the part worth reviewing first, because it means past green runs proved less than
they appeared to.

**Both ASH scan steps pipe into `tee` with no `pipefail`.** In a pipeline, the shell reports
the exit status of the *last* command — `tee`, which essentially always succeeds. A failing
security scan therefore reported success. No workflow in the repo set `pipefail` anywhere.

```diff
-        run: ash --mode container 2>&1 | tee ash-output.log
-        continue-on-error: true
+        run: |
+          set -o pipefail
+          ash --mode container 2>&1 | tee ash-output.log
```

**The full-repository ASH scan also had `continue-on-error: true`**, so even with `pipefail`
it could not have blocked. A scan that cannot fail the build is reporting, not gating.
Removing it is the change most likely to newly-fail a build, so it deserves the closest look:
if the intent was advisory-only, the right fix is to keep `continue-on-error` and say so in a
comment, and I am happy to change it to that.

## Supply chain

**`tj-actions/changed-files@v46` is a mutable tag.** A tag on this action was compromised in
March 2025 (CVE-2025-30066) to leak CI secrets. Four workflows referenced it by tag. All are
now pinned to the immutable commit SHA for v47.0.6,
`9426d40962ed5378910ee2e21d5f8c6fcbf2dd96`, resolved via the GitHub API rather than copied
from a third party.

**Changed filenames were interpolated straight into `run:` blocks** as
`${{ steps.changed-files.outputs.all_changed_files }}`. Because a fork PR controls its own
filenames, that is a command injection sink. They now arrive through `env:` and are
referenced as `${CHANGED_FILES}`.

**`python-tests.yml` had no `permissions:` block**, which grants the job an implicit
write-all token. Five of the seven workflows already declared `contents: read`; this brings
the sixth in line. (checkov CKV2_GHA_1.)

## A dependency pin that silently did nothing

```yaml
pip install pydantic>=2.0.0     # unquoted
```

`>=` is a shell redirect. This wrote an empty file named `=2.0.0` into the working directory
and installed pydantic **completely unconstrained** — the opposite of the intent. Now quoted,
and bounded to match the Lambda runtime requirement in
`finserv_assessments/requirements.txt` (`pydantic>=2.0.0,<3.0.0`) so CI cannot pass against a
pydantic major the deployed function forbids. `tests/requirements.txt` gets the same bound
for the same reason.

## Reproducibility

`ruff` and `cfn-lint` were installed unpinned, so an upstream release turns into a red build
on an unrelated PR. Pinned to `ruff==0.16.2` and `cfn-lint==1.54.0`.

## Coverage gaps

**Both SAM templates were validated but only one was built**, so a build break affecting only
`template-multi-account.yaml` could ship undetected. Added a second build step writing to
`.aws-sam/build-multi`.

**`python-tests.yml`'s path filter omitted files the suite asserts against** — both
templates, the state machine, `deployment/`, `buildspec.yml`, `docs/`. A change to any of
them could break tests without running them. The `push` and `pull_request` lists were also
duplicated, so they could drift; they now share one list.

## Notes for review

**The shared path list uses a YAML anchor** (`&test-paths` / `*test-paths`). GitHub Actions is
widely described as not supporting YAML anchors, and if the alias did not expand the
`pull_request` filter would break and the test job would silently stop running — the opposite
of the intent. It does work: anchors are resolved by the YAML parser before Actions evaluates
expressions. Verified on
[run 31220857445](https://github.com/aws-samples/sample-aiml-security-assessment/actions/runs/31220857445),
where the `pull_request` filter matched and the suite ran 1,393 tests. Flagging it because
it is an uncommon thing to rely on; if maintainers would rather not, the fix is to duplicate
the list and accept the drift risk.

**This branch does not add `ruff.toml`, and that has a sequencing consequence.** The repo has
no ruff config, so pinning the binary makes the gate reproducible but locks in 0.16.2's
*default* rule set, which is far broader than the one this codebase was written to — it
reports 935 findings repo-wide on unmodified `main`. So:

- If this PR lands first, the next PR touching Python hits those 935 defaults.
- PR #54 adds `ruff.toml` with `select = ["E4", "E7", "E9", "F"]`, restoring the intended
  ruleset. On that branch, the twelve changed Python files go from 232 errors
  (`--isolated`) to zero.

Either take `ruff.toml` from #54 first, or move it into this PR. I have kept it in #54
because that branch cannot pass lint without it, but I am happy to move it here if
maintainers would rather the lint config travel with the lint pin.

**Two path triggers name files that do not exist on this branch** — `ruff.toml` and
`generate_provenance.py`, both added by PR #54. A `paths` entry for a nonexistent file simply
never matches, so both are inert until that branch lands.

## Merge safety

The only file shared with PR #54 is `tests/requirements.txt`, edited in different regions.
`git merge-tree --write-tree` reports a clean automatic merge, and the merged result contains
both changes. **The two PRs can land in either order.**

## Verification

- All six workflow files parse as valid YAML.
- No `.py` files changed, so `python-lint` correctly skips on this PR.
- The `pydantic>=2.0.0,<3.0.0` bound matches
  `aiml-security-assessment/functions/security/finserv_assessments/requirements.txt`,
  confirmed by reading it; `TestRequirementVersionFloors` asserts against that Lambda file,
  not `tests/requirements.txt`, so this change does not affect it.
- The `tj-actions/changed-files` SHA was resolved to v47.0.6 through the GitHub API.
