### PR TITLE
Fix BR-16 unknown tier handling and clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # AWS AI/ML Security Assessment for Amazon Bedrock, Amazon SageMaker AI, and Amazon Bedrock AgentCore
 
-*A serverless framework that scans your AWS accounts for AI/ML security misconfigurations and produces an interactive, shareable report.*
+*A serverless framework based assessment that scans your AWS accounts for AI/ML security misconfigurations and produces an interactive, shareable report.*
 
 [![License: MIT-0](https://img.shields.io/badge/License-MIT--0-yellow.svg)](https://opensource.org/licenses/MIT-0) [![Python 3.12](https://img.shields.io/badge/Python-3.12-blue.svg)](https://www.python.org/downloads/) [![AWS SAM](https://img.shields.io/badge/AWS-SAM-orange.svg)](https://aws.amazon.com/serverless/sam/)
 
-**Open-source automated security scanner for generative AI and machine learning workloads on AWS.** Core checks for Amazon Bedrock, Amazon SageMaker AI, and Amazon Bedrock AgentCore are built on the [AWS Well-Architected Framework — Generative AI Lens](https://docs.aws.amazon.com/wellarchitected/latest/generative-ai-lens/generative-ai-lens.html). An optional **Responsible AI GRC** module adds 64 checks — cross-industry technical controls for AI governance, risk, and compliance — informed by the [AWS User Guide to Governance, Risk, and Compliance for Responsible AI Adoption](https://d1.awsstatic.com/whitepapers/compliance/AWS-User-Guide-Governance-Risk-Compliance-for-Responsible-AI-Adoption-Financial-Services.pdf) (the AWS GRC User Guide) and by AWS financial-services generative-AI risk guidance. See the [AWS Security Blog announcement](https://aws.amazon.com/blogs/security/introducing-the-updated-aws-user-guide-to-governance-risk-and-compliance-for-responsible-ai-adoption/) for context on the updated guide.
+**Open-source automated security scanner for generative AI and machine learning workloads on AWS.** It brings together assessments for Amazon Bedrock, Amazon SageMaker AI, and Amazon Bedrock AgentCore. Core checks are guided by the [AWS Well-Architected Generative AI Lens](https://docs.aws.amazon.com/wellarchitected/latest/generative-ai-lens/generative-ai-lens.html). The optional **Responsible AI GRC** module adds technical checks for AI governance, risk, and compliance. Optional **OWASP Top 10 for LLM** checks extend coverage across common LLM security risks. Responsible AI GRC checks draw on the [AWS User Guide to Governance, Risk, and Compliance for Responsible AI Adoption](https://d1.awsstatic.com/whitepapers/compliance/AWS-User-Guide-Governance-Risk-Compliance-for-Responsible-AI-Adoption-Financial-Services.pdf).
 
-> **Responsible AI GRC is not the [AWS Well-Architected Responsible AI Lens](https://docs.aws.amazon.com/wellarchitected/latest/responsible-ai-lens/responsible-ai-lens.html).** The Lens (November 2025) is a separate architectural review framework with eight focus areas. These 64 checks do not implement, validate, or measure conformance to it, and passing them does not indicate Lens alignment. They evaluate selected AWS configuration evidence and do not establish regulatory compliance or certify a system as responsible AI; regulatory framework mappings are preliminary. See [Responsible AI GRC — scope, sources, and compatibility](docs/RESPONSIBLE_AI_GRC_SCOPE.md).
->
-> These controls originated as financial-services controls and were found applicable across multiple industries — which the AWS GRC User Guide itself now reflects, having dropped "within Financial Services Industries" from its title in the 2026-05-13 update. The `FS-*` check IDs are retained permanently as compatibility contracts, and `EnableFinServAssessment` is retained as a legacy alias for `EnableResponsibleAIGRCAssessment`.
+Run **[174 checks](docs/SECURITY_CHECKS.md)** across AWS accounts and regions:
 
-Run **[174 security checks](docs/SECURITY_CHECKS.md)** across your AWS accounts and regions in one deployment. Surfaces IAM misconfigurations, encryption gaps, network isolation issues, missing guardrails, and governance gaps — with interactive HTML reports, severity ratings, and AWS documentation links for remediation. Single-account or full AWS Organizations multi-account scans; all data stays in your account.
+- **71 always-on core checks** for Amazon Bedrock, Amazon SageMaker AI, and Amazon Bedrock AgentCore
+- **27 always-on Agentic AI Security checks**, synthesized from service findings and native AgentCore gateway checks
+- **64 optional Responsible AI GRC checks** for selected technical controls informed by AWS governance, risk, and compliance guidance
+- **12 optional OWASP Top 10 for LLM checks**, including mapping-based coverage and native system-prompt-leakage checks
+
+Deploy in a single account or across AWS Organizations. Assessments support multi-region execution and produce interactive, shareable reports with severity ratings, filtering, search, remediation references, and per-account/per-region views. Assessment artifacts are stored in your AWS account; the deployment build pulls source from the configured repository.
+
+> **Scope note:** Responsible AI GRC provides selected AWS configuration checks for AI governance, risk, and compliance. It complements architectural reviews such as the AWS Well-Architected Responsible AI Lens and broader compliance programs. See [Responsible AI GRC scope, sources, and compatibility](docs/RESPONSIBLE_AI_GRC_SCOPE.md).
 
 ---
 

--- a/aiml-security-assessment/functions/security/bedrock_assessments/app.py
+++ b/aiml-security-assessment/functions/security/bedrock_assessments/app.py
@@ -3229,11 +3229,24 @@ def check_bedrock_guardrail_tier(region: str = "") -> Dict[str, Any]:
 
                 # The content-filter tier is reported under
                 # contentPolicy.tier.tierName. Valid values are CLASSIC and
-                # STANDARD; STANDARD is the more robust tier. When a guardrail has
-                # no content policy the field is absent, so default to CLASSIC
-                # (the baseline) rather than assuming the enhanced tier.
+                # STANDARD; STANDARD is the more robust tier. If the field is
+                # absent, the tier is unknown and must not be inferred.
                 content_policy = guardrail_config.get("contentPolicy", {})
-                tier = content_policy.get("tier", {}).get("tierName", "CLASSIC")
+                tier = content_policy.get("tier", {}).get("tierName")
+
+                if not tier:
+                    unassessed_guardrails.append(
+                        {
+                            "name": guardrail_name,
+                            "id": guardrail_id,
+                            "reason": (
+                                "GetGuardrail did not report "
+                                "contentPolicy.tier.tierName; tier unknown "
+                                "and was not assumed to be CLASSIC"
+                            ),
+                        }
+                    )
+                    continue
 
                 if tier != "STANDARD":
                     suboptimal_guardrails.append(
@@ -3279,13 +3292,40 @@ def check_bedrock_guardrail_tier(region: str = "") -> Dict[str, Any]:
             if unassessed_guardrails:
                 findings["status"] = "WARN"
                 for gr in unassessed_guardrails:
+                    if "reason" in gr:
+                        finding_details = (
+                            f"Guardrail '{gr['name']}' (ID: {gr['id']}) "
+                            f"could not be assessed because {gr['reason']}."
+                        )
+                        resolution = (
+                            "Review the guardrail configuration and rerun the "
+                            "assessment after GetGuardrail reports the content-filter tier."
+                        )
+                        reference = (
+                            "https://docs.aws.amazon.com/bedrock/latest/userguide/"
+                            "guardrails-components.html"
+                        )
+                    else:
+                        finding_details = (
+                            f"Guardrail '{gr['name']}' (ID: {gr['id']}) could not "
+                            f"be assessed because GetGuardrail returned {gr['error']}."
+                        )
+                        resolution = (
+                            "Retry the assessment. If the error persists, grant "
+                            "bedrock:GetGuardrail and verify the guardrail still exists."
+                        )
+                        reference = (
+                            "https://docs.aws.amazon.com/bedrock/latest/userguide/"
+                            "security_iam_id-based-policy-examples.html"
+                        )
+
                     findings["csv_data"].append(
                         create_finding(
                             check_id="BR-16",
                             finding_name="Guardrail Tier Validation Check",
-                            finding_details=f"Guardrail '{gr['name']}' (ID: {gr['id']}) could not be assessed because GetGuardrail returned {gr['error']}.",
-                            resolution="Retry the assessment. If the error persists, grant bedrock:GetGuardrail and verify the guardrail still exists.",
-                            reference="https://docs.aws.amazon.com/bedrock/latest/userguide/security_iam_id-based-policy-examples.html",
+                            finding_details=finding_details,
+                            resolution=resolution,
+                            reference=reference,
                             severity="Informational",
                             status="N/A",
                             region=region,

--- a/tests/test_bedrock_checks.py
+++ b/tests/test_bedrock_checks.py
@@ -1698,6 +1698,32 @@ class TestBR16GuardrailTier:
         assert passed_findings[0]["Check_ID"] == "BR-16"
 
     @patch("bedrock_app.boto3.client")
+    def test_br16_absent_tier_returns_na_without_assuming_classic(self, mock_client):
+        check = bedrock_app.check_bedrock_guardrail_tier
+
+        bedrock_client = MagicMock()
+        bedrock_client.list_guardrails.return_value = {
+            "guardrails": [{"id": "gr-123", "name": "tierless-guardrail"}]
+        }
+        bedrock_client.get_guardrail.return_value = {
+            "guardrail": {"contentPolicy": {"filters": []}}
+        }
+        mock_client.return_value = bedrock_client
+
+        result = check(region="us-east-1")
+        findings = extract_csv_data(result)
+
+        assert len(findings) == 1
+        assert findings[0]["Status"] == "N/A"
+        assert findings[0]["Severity"] == "Informational"
+        assert "tier unknown" in findings[0]["Finding_Details"]
+        assert "not assumed to be CLASSIC" in findings[0]["Finding_Details"]
+        assert (
+            "is using the 'CLASSIC' content-filter tier"
+            not in findings[0]["Finding_Details"]
+        )
+
+    @patch("bedrock_app.boto3.client")
     def test_br16_non_standard_tier_returns_failed(self, mock_client):
         check = bedrock_app.check_bedrock_guardrail_tier
 


### PR DESCRIPTION
*Description of changes:*

Summary

- Clarify the README’s opening scope and feature coverage.
- Add upfront references to Responsible AI GRC and OWASP Top 10 for LLM.
- Fix BR-16 to avoid assuming missing guardrail tiers are CLASSIC.
- Report unknown tiers as N/A with Informational severity.
- Add regression coverage for missing-tier responses.

Testing

- pytest tests/ -v --tb=short — 663 passed
- ruff check — passed
- ruff format --check — passed
- git diff --check — passed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.